### PR TITLE
Remove stale TROUBLESHOOTING references

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Welcome to the **TEST Squadron Discord Bot** repository. This bot helps manage u
   - **`__init__.py`**: Reserved for future data storage needs.
 - **`requirements.txt`**: Lists the dependencies required for the project.
 - **`SETUP.txt`**: Guide on setting up the bot locally, including instructions for configuring environment variables.
-- **`TROUBLESHOOTING.txt`**: Common issues and how to fix them.
 - **`Commands.txt`**: List of available commands.
 
 ## 🛠️ Getting Started

--- a/SETUP.txt
+++ b/SETUP.txt
@@ -50,9 +50,6 @@ AFFILIATE_ROLE_ID=your_affiliate_role_id NON_MEMBER_ROLE_ID=your_non_member_role
 
 ## 🎉 You're All Set!
 
-The bot should now be running locally. If you encounter any issues, check out the `TROUBLESHOOTING.txt` for common problems and solutions.
+The bot should now be running locally.
 
 Happy Testing! 🚀
-
-
-


### PR DESCRIPTION
## Summary
- drop the obsolete troubleshooting entry from the project structure list
- simplify the setup guide closing section

------
https://chatgpt.com/codex/tasks/task_b_686329cada5083338e0aed248a5e60d4