### PR TITLE
Add persistent re-check with configurable cooldown

### DIFF
--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -4,10 +4,22 @@ import discord
 from discord.ext import commands
 import json
 import os
+import time
+from aiolimiter import AsyncLimiter
 
-from helpers.embeds import create_verification_embed
+from helpers.embeds import (
+    create_verification_embed,
+    create_error_embed,
+    create_success_embed,
+    create_cooldown_embed,
+)
 from helpers.views import VerificationView
 from helpers.logger import get_logger
+from helpers.database import Database
+from helpers.role_helper import reverify_member, get_welcome_description
+from helpers.discord_api import followup_send_message
+from config.config_loader import ConfigLoader
+from verification.rsi_verification import lookup_rsi_user
 
 logger = get_logger(__name__)
 
@@ -23,8 +35,15 @@ class VerificationCog(commands.Cog):
             bot (commands.Bot): The bot instance.
         """
         self.bot = bot
+        self.config = ConfigLoader.load_config()
+        self.recheck_cooldown = self.config.get('verification', {}).get('recheck_cooldown_seconds', 300)
+        self.rsi_limiter = AsyncLimiter(1, 1)
         # Schedule the verification message to be sent after the bot is ready
         self.bot.loop.create_task(self.wait_and_send_verification_message())
+
+    async def cog_load(self):
+        """Register the persistent verification view when the cog loads."""
+        self.bot.add_view(VerificationView(self.bot))
 
     async def wait_and_send_verification_message(self):
         """
@@ -85,6 +104,51 @@ class VerificationCog(commands.Cog):
             logger.error("Bot lacks permission to send messages in the verification channel.")
         except discord.HTTPException as e:
             logger.exception(f"Failed to send verification message: {e}")
+
+    async def recheck_button(self, interaction: discord.Interaction):
+        """Handle the Re-Check button interaction."""
+        await interaction.response.defer(ephemeral=True)
+
+        user_id = interaction.user.id
+        async with Database.get_connection() as db:
+            cursor = await db.execute(
+                "SELECT rsi_handle, last_recheck FROM verification WHERE user_id = ?",
+                (user_id,)
+            )
+            row = await cursor.fetchone()
+
+        if not row:
+            embed = create_error_embed("You are not verified yet.")
+            await followup_send_message(interaction, "", embed=embed, ephemeral=True)
+            return
+
+        rsi_handle, last_recheck = row
+        now = int(time.time())
+        if last_recheck and now - last_recheck < self.recheck_cooldown:
+            wait_until = last_recheck + self.recheck_cooldown
+            embed = create_cooldown_embed(wait_until)
+            await followup_send_message(interaction, "", embed=embed, ephemeral=True)
+            return
+
+        async with Database.get_connection() as db:
+            await db.execute(
+                "UPDATE verification SET last_recheck = ? WHERE user_id = ?",
+                (now, user_id),
+            )
+            await db.commit()
+
+        async with self.rsi_limiter:
+            verify_value, cased_handle = await lookup_rsi_user(rsi_handle, self.bot.http_client)
+
+        if verify_value is None or cased_handle is None:
+            embed = create_error_embed("Failed to look up your RSI status. Please try again later.")
+            await followup_send_message(interaction, "", embed=embed, ephemeral=True)
+            return
+
+        assigned_role_type = await reverify_member(interaction.user, verify_value, cased_handle, self.bot)
+        description = get_welcome_description(assigned_role_type)
+        embed = create_success_embed(description)
+        await followup_send_message(interaction, "", embed=embed, ephemeral=True)
 
 async def setup(bot: commands.Bot):
     """

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,6 +33,9 @@ voice:
   cooldown_seconds: 5  # Cooldown period in seconds
   expiry_days: 30  # Expiry period for voice channel data in days
 
+verification:
+  recheck_cooldown_seconds: 300  # Cooldown for using the re-check button
+
 
 database:
   path: "TESTDatabase.db"

--- a/helpers/database.py
+++ b/helpers/database.py
@@ -29,14 +29,21 @@ class Database:
     @classmethod
     async def _create_tables(cls, db):
         # Create verification table
-        await db.execute("""
+        await db.execute(
+            """
             CREATE TABLE IF NOT EXISTS verification (
                 user_id INTEGER PRIMARY KEY,
                 rsi_handle TEXT NOT NULL,
                 membership_status TEXT NOT NULL,
-                last_updated INTEGER NOT NULL
+                last_updated INTEGER NOT NULL,
+                last_recheck INTEGER DEFAULT 0
             )
-        """)
+            """
+        )
+        try:
+            await db.execute("ALTER TABLE verification ADD COLUMN last_recheck INTEGER DEFAULT 0")
+        except Exception:
+            pass
         # Create or update voice tables
         # In _create_tables method
         await db.execute("""

--- a/helpers/modals.py
+++ b/helpers/modals.py
@@ -8,7 +8,7 @@ from helpers.embeds import create_error_embed, create_success_embed, create_cool
 from helpers.rate_limiter import log_attempt, get_remaining_attempts, check_rate_limit, reset_attempts
 from helpers.token_manager import token_store, validate_token, clear_token
 from verification.rsi_verification import is_valid_rsi_handle, is_valid_rsi_bio
-from helpers.role_helper import assign_roles
+from helpers.role_helper import assign_roles, get_welcome_description
 from helpers.logger import get_logger
 from helpers.voice_utils import get_user_channel, update_channel_settings
 from helpers.discord_api import (
@@ -127,37 +127,8 @@ class HandleModal(Modal, title="Verification"):
         clear_token(member.id)
         reset_attempts(member.id)
 
-        # Send customized success message based on role
-        if assigned_role_type == 'main':
-            description = (
-                "<:testSquad:1332572066804928633> **Welcome, to TEST Squadron - Best Squadron!** <:BESTSquad:1332572087524790334>\n\n"
-                "We're thrilled to have you as a MAIN member of **TEST Squadron!**\n\n"
-                "Join our voice chats, explore events, and engage in our text channels to make the most of your experience!\n\n"
-                "Fly safe! <:o7:1332572027877593148>"
-            )
-        elif assigned_role_type == 'affiliate':
-            description = (
-                "<:testSquad:1332572066804928633> **Welcome, to TEST Squadron - Best Squadron!** <:BESTSquad:1332572087524790334>\n\n"
-                "Your support helps us grow and excel. We encourage you to set **TEST** as your MAIN Org to show your loyalty.\n\n"
-                "**Instructions:**\n"
-                ":point_right: [Change Your Main Org](https://robertsspaceindustries.com/account/organization)\n"
-                "1️⃣ Click **Set as Main** next to **TEST Squadron**.\n\n"
-                "Join our voice chats, explore events, and engage in our text channels to get involved!\n\n"
-                "<:o7:1332572027877593148>"
-            )
-        elif assigned_role_type == 'non_member':
-            description = (
-                "<:testSquad:1332572066804928633> **Welcome, to TEST Squadron - Best Squadron!** <:BESTSquad:1332572087524790334>\n\n"
-                "It looks like you're not yet a member of our org. <:what:1332572046638452736>\n\n"
-                "Join us for thrilling adventures and be part of the best and biggest community!\n\n"
-                "🔗 [Join TEST Squadron](https://robertsspaceindustries.com/orgs/TEST)\n"
-                "*Click **Enlist Now!**. Test membership requests are usually approved within 24-72 hours. "
-                "You will need to reverify to update your roles once approved.*\n\n"
-                "Join our voice chats, explore events, and engage in our text channels to get involved! <:o7:1332572027877593148>"
-            )
-        else:
-            description = "Welcome to the server! You can verify again after 3 hours if needed."
-
+        # Build role-specific success message
+        description = get_welcome_description(assigned_role_type)
         embed = create_success_embed(description)
 
         # 9) Send follow-up success

--- a/helpers/views.py
+++ b/helpers/views.py
@@ -87,10 +87,11 @@ class FilteredRoleSelect(Select):
 class VerificationView(View):
     """
     View containing interactive buttons for the verification process.
-    
-    Contains two buttons:
+
+    Contains three buttons:
       - Get Token: Generates and sends a verification token.
       - Verify: Opens a modal to collect the user's RSI handle.
+      - Re-Check: Re-checks a user's org status and updates roles.
     """
     def __init__(self, bot):
         super().__init__(timeout=None)
@@ -111,6 +112,14 @@ class VerificationView(View):
         )
         self.verify_button.callback = self.verify_button_callback
         self.add_item(self.verify_button)
+
+        self.recheck_button = Button(
+            label="Re-Check",
+            style=discord.ButtonStyle.secondary,
+            custom_id="verification_recheck_button"
+        )
+        self.recheck_button.callback = self.recheck_button_callback
+        self.add_item(self.recheck_button)
 
     async def get_token_button_callback(self, interaction: Interaction):
         """
@@ -155,6 +164,17 @@ class VerificationView(View):
 
         modal = HandleModal(self.bot)
         await interaction.response.send_modal(modal)
+
+    async def recheck_button_callback(self, interaction: Interaction):
+        """
+        Callback for the 'Re-Check' button. Delegates handling to the
+        VerificationCog if available.
+        """
+        cog = self.bot.get_cog("VerificationCog")
+        if cog and hasattr(cog, "recheck_button"):
+            await cog.recheck_button(interaction)
+        else:
+            await send_message(interaction, "Re-check feature unavailable.", ephemeral=True)
 
 # -------------------------
 # Channel Settings + Permissions

--- a/verification/rsi_verification.py
+++ b/verification/rsi_verification.py
@@ -242,3 +242,8 @@ def extract_bio(html_content: str) -> Optional[str]:
     else:
         logger.warning("Bio section not found in profile HTML.")
     return None
+
+
+async def lookup_rsi_user(user_handle: str, http_client: HTTPClient) -> Tuple[Optional[int], Optional[str]]:
+    """Lookup RSI organization status for a handle."""
+    return await is_valid_rsi_handle(user_handle, http_client)


### PR DESCRIPTION
## Summary
- include cooldown and success/error embeds in re-check logic
- add helper to share role-specific success copy
- register re-check button with persistent id
- look up cooldown value from config
- document verification re-check cooldown in config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866e5e0046c83339f23ac8603af7535

## Summary by Sourcery

Introduce a persistent "Re-Check" feature that allows users to refresh their RSI organization status on demand, with a configurable cooldown enforced and stored across restarts.

New Features:
- Add a persistent "Re-Check" button in the verification view to let users re-verify their org status.
- Implement recheck handler in VerificationCog that checks and updates RSI membership, enforces cooldown, and sends success/error/cooldown embeds.
- Load the re-check cooldown interval from configuration and persist last_recheck timestamps in the database.
- Integrate a rate limiter (AsyncLimiter) and lookup_rsi_user helper to throttle and perform RSI API calls.

Enhancements:
- Extract success, error, and cooldown embed creation into dedicated helper functions.
- Centralize role-specific welcome message generation via get_welcome_description.
- Update and migrate the verification database schema to include a last_recheck column.
- Register the VerificationView persistently on cog load so buttons survive bot restarts.

Documentation:
- Document the re-check cooldown setting in config.yaml under verification.recheck_cooldown_seconds.