### PR TITLE
Implement re-check button flow

### DIFF
--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -4,10 +4,21 @@ import discord
 from discord.ext import commands
 import json
 import os
+import time
 
-from helpers.embeds import create_verification_embed
+from config.config_loader import ConfigLoader
+from helpers.database import Database
+from helpers.embeds import (
+    create_verification_embed,
+    create_error_embed,
+    create_success_embed,
+    create_cooldown_embed,
+    build_welcome_description,
+)
 from helpers.views import VerificationView
 from helpers.logger import get_logger
+from helpers.discord_api import followup_send_message
+from helpers.role_helper import reverify_member
 
 logger = get_logger(__name__)
 
@@ -85,6 +96,48 @@ class VerificationCog(commands.Cog):
             logger.error("Bot lacks permission to send messages in the verification channel.")
         except discord.HTTPException as e:
             logger.exception(f"Failed to send verification message: {e}")
+
+    async def recheck_button(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        member = interaction.user
+
+        config = ConfigLoader.load_config()
+        cooldown = config['rate_limits'].get('recheck_window_seconds', 300)
+        async with Database.get_connection() as db:
+            cursor = await db.execute(
+                "SELECT rsi_handle, last_recheck FROM verification WHERE user_id = ?",
+                (member.id,)
+            )
+            row = await cursor.fetchone()
+            if not row:
+                embed = create_error_embed("You are not verified yet. Please click Verify first.")
+                await followup_send_message(interaction, "", embed=embed, ephemeral=True)
+                return
+            rsi_handle, last_recheck = row
+            last_recheck = last_recheck or 0
+
+        now = int(time.time())
+        if now - last_recheck < cooldown:
+            embed = create_cooldown_embed(last_recheck + cooldown)
+            await followup_send_message(interaction, "", embed=embed, ephemeral=True)
+            return
+
+        success, role_type, error_msg = await reverify_member(member, rsi_handle, self.bot)
+        if not success:
+            embed = create_error_embed(error_msg or "Re-check failed. Please try again later.")
+            await followup_send_message(interaction, "", embed=embed, ephemeral=True)
+            return
+
+        async with Database.get_connection() as db:
+            await db.execute(
+                "UPDATE verification SET last_recheck = ? WHERE user_id = ?",
+                (now, member.id),
+            )
+            await db.commit()
+
+        description = build_welcome_description(role_type)
+        embed = create_success_embed(description)
+        await followup_send_message(interaction, "", embed=embed, ephemeral=True)
 
 async def setup(bot: commands.Bot):
     """

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,6 +3,7 @@ bot:
 rate_limits:
   max_attempts: 5
   window_seconds: 1800  # 30 min
+  recheck_window_seconds: 300
 organization:
   name: "TEST Squadron - Best Squardon!" 
 

--- a/docs/recheck_feature_plan.md
+++ b/docs/recheck_feature_plan.md
@@ -1,0 +1,50 @@
+# Re-Check Feature Plan
+
+This document outlines the planned enhancements required to add a **Re-Check** option for already verified members. It builds on the existing verification workflow described in `docs/verification_workflow.md`.
+
+## 1. Required Enhancements
+
+- **Cooldown Display**: Replace the plain-text countdown with `create_cooldown_embed` and `followup_send_message` so users see a consistent embed during cooldown periods.
+- **Embed Factories**: Use `create_error_embed` and `create_success_embed` for all messages shown during the re-check process.
+- **Welcome Embeds**: After a successful re-check, send role-specific welcome embeds: `main`, `affiliate`, and `non_member`.
+- **Button ID**: Standardize the re-check button with the persistent ID `"verification_recheck_button"`.
+- **Rate Limit Configuration**: Move the 300‑second cooldown into `config.yaml` as `rate_limits.recheck_window_seconds` (or rely on `check_rate_limit` if consolidated).
+- **Database Migration**: Add a migration creating a new `last_recheck INTEGER DEFAULT 0` column in the `verification` table.
+
+## 2. Implementation Plan
+
+- **helpers/embeds.py**
+  - Add helper functions for welcome embeds if not already present (e.g., `build_welcome_description`).
+  - Ensure `create_cooldown_embed` is reused for the re-check flow.
+- **helpers/views.py**
+  - Introduce a new `RecheckView` or extend `VerificationView` with a re-check button using ID `verification_recheck_button`.
+  - Hook the button to open `HandleModal` without token generation.
+- **cogs/verification.py**
+  - Send the updated view containing the re-check button when posting the verification message.
+  - Handle follow-up messaging logic via centralized helpers.
+- **helpers/discord_api.py**
+  - Continue using `followup_send_message` for all ephemeral responses.
+- **config/config.yaml**
+  - Add `rate_limits.recheck_window_seconds: 300` and load this value in `rate_limiter.py` or new helper.
+- **Database migration**
+  - Create a migration script that adds `last_recheck` to the `verification` table with a default of `0`.
+- **helpers/rate_limiter.py**
+  - Extend `check_rate_limit` or introduce a similar helper for re-check attempts referencing the new config value.
+- **Unit/Integration Tests**
+  - Update existing verification tests to cover the new button and cooldown.
+  - Add tests ensuring role-specific welcome embeds are sent after a re-check.
+  - Confirm DB writes to `last_recheck`.
+
+## 3. Proposed Re-Check Workflow
+
+```mermaid
+flowchart TD
+    A[Re-Check Button Click] --> B[check_rate_limit / config.recheck_window_seconds]
+    B -->|limited| C[Cooldown embed]
+    B -->|allowed| D[HandleModal]
+    D --> E[is_valid_rsi_handle & is_valid_rsi_bio]
+    E -->|fail| F[Error embed]
+    E -->|success| G[assign_roles]
+    G --> H[Send role-specific welcome embed]
+    G --> I[Update last_recheck in DB]
+```

--- a/docs/verification_workflow.md
+++ b/docs/verification_workflow.md
@@ -1,0 +1,36 @@
+# Verification Workflow
+
+This document describes how the bot verifies users based on their RSI (Star Citizen) profile.
+It also highlights where a future **Re‑Check** feature would integrate.
+
+## Overview
+- **Channel Message**: On startup the bot sends a verification embed to the configured channel. This embed contains the `Get Token` and `Verify` buttons ([`VerificationView`](../helpers/views.py)).
+- **Token Generation**: Selecting **Get Token** checks the rate limit and, if allowed, generates a 4‑digit PIN using [`generate_token`](../helpers/token_manager.py). The PIN expires after 15 minutes and is shown in an ephemeral embed ([`create_token_embed`](../helpers/embeds.py)).
+- **Handle Submission**: Selecting **Verify** opens [`HandleModal`](../helpers/modals.py) where the user enters their RSI handle. The modal validates:
+  1. RSI handle format.
+  2. Membership in the TEST organization via [`is_valid_rsi_handle`](../verification/rsi_verification.py).
+  3. That a valid token exists and is present in the user’s RSI bio via [`is_valid_rsi_bio`](../verification/rsi_verification.py).
+- **Role Assignment**: If checks succeed, [`assign_roles`](../helpers/role_helper.py) grants `BotVerified` plus the appropriate org role (Main/Affiliate/Non‑Member). Verification attempts and tokens are cleared.
+- **Rate Limiting**: All verification actions are limited by [`check_rate_limit`](../helpers/rate_limiter.py). Exceeding the limit sends a cooldown embed.
+
+## Where Re‑Check Fits
+A future **Re‑Check** action could reuse the HandleModal logic to update roles for users who are already verified. It would trigger the same validations as **Verify** but skip token generation, allowing members to refresh their status.
+
+## Mermaid Diagram
+```mermaid
+flowchart TD
+    A[Bot Startup] --> B[Send verification embed\nwith Get Token & Verify buttons]
+    B -->|Get Token| C[check_rate_limit]
+    C -->|limited| C2[Cooldown embed]
+    C -->|allowed| D[generate_token]
+    D --> E[Ephemeral token embed]
+    B -->|Verify| F[check_rate_limit]
+    F -->|limited| C2
+    F -->|allowed| G[HandleModal]
+    G --> H[is_valid_rsi_handle]
+    H --> I[validate_token]
+    I --> J[is_valid_rsi_bio]
+    J -->|fail| K[Error embed & attempt logged]
+    J -->|success| L[assign_roles]
+    L --> M[Success embed]
+```

--- a/helpers/database.py
+++ b/helpers/database.py
@@ -29,14 +29,22 @@ class Database:
     @classmethod
     async def _create_tables(cls, db):
         # Create verification table
-        await db.execute("""
+        await db.execute(
+            """
             CREATE TABLE IF NOT EXISTS verification (
                 user_id INTEGER PRIMARY KEY,
                 rsi_handle TEXT NOT NULL,
                 membership_status TEXT NOT NULL,
                 last_updated INTEGER NOT NULL
             )
-        """)
+            """
+        )
+        cursor = await db.execute("PRAGMA table_info(verification)")
+        columns = [row[1] for row in await cursor.fetchall()]
+        if "last_recheck" not in columns:
+            await db.execute(
+                "ALTER TABLE verification ADD COLUMN last_recheck INTEGER DEFAULT 0"
+            )
         # Create or update voice tables
         # In _create_tables method
         await db.execute("""

--- a/helpers/embeds.py
+++ b/helpers/embeds.py
@@ -126,3 +126,34 @@ def create_cooldown_embed(wait_until: int) -> discord.Embed:
     color = 0xFFA500  # Orange
     thumbnail_url = "https://testsquadron.com/styles/custom/logos/TEST-Simplified-Yellow.png"
     return create_embed(title, description, color, thumbnail_url)
+
+
+def build_welcome_description(role_type: str) -> str:
+    """Return a role-specific welcome message."""
+    if role_type == "main":
+        return (
+            "<:testSquad:1332572066804928633> **Welcome, to TEST Squadron - Best Squadron!** <:BESTSquad:1332572087524790334>\n\n"
+            "We're thrilled to have you as a MAIN member of **TEST Squadron!**\n\n"
+            "Join our voice chats, explore events, and engage in our text channels to make the most of your experience!\n\n"
+            "Fly safe! <:o7:1332572027877593148>"
+        )
+    if role_type == "affiliate":
+        return (
+            "<:testSquad:1332572066804928633> **Welcome, to TEST Squadron - Best Squadron!** <:BESTSquad:1332572087524790334>\n\n"
+            "Your support helps us grow and excel. We encourage you to set **TEST** as your MAIN Org to show your loyalty.\n\n"
+            "**Instructions:**\n"
+            ":point_right: [Change Your Main Org](https://robertsspaceindustries.com/account/organization)\n"
+            "1️⃣ Click **Set as Main** next to **TEST Squadron**.\n\n"
+            "Join our voice chats, explore events, and engage in our text channels to get involved!\n\n"
+            "<:o7:1332572027877593148>"
+        )
+    if role_type == "non_member":
+        return (
+            "<:testSquad:1332572066804928633> **Welcome, to TEST Squadron - Best Squadron!** <:BESTSquad:1332572087524790334>\n\n"
+            "It looks like you're not yet a member of our org. <:what:1332572046638452736>\n\n"
+            "Join us for thrilling adventures and be part of the best and biggest community!\n\n"
+            "🔗 [Join TEST Squadron](https://robertsspaceindustries.com/orgs/TEST)\n"
+            "*Click **Enlist Now!**. Test membership requests are usually approved within 24-72 hours. You will need to reverify to update your roles once approved.*\n\n"
+            "Join our voice chats, explore events, and engage in our text channels to get involved! <:o7:1332572027877593148>"
+        )
+    return "Welcome to the server! You can verify again after 3 hours if needed."

--- a/helpers/role_helper.py
+++ b/helpers/role_helper.py
@@ -140,3 +140,15 @@ def can_modify_nickname(member: discord.Member) -> bool:
     can_modify = bot_member.top_role > member.top_role
     logger.debug(f"Can modify nickname: {can_modify} (Bot Top Role: {bot_member.top_role}, Member Top Role: {member.top_role})")
     return can_modify
+
+
+async def reverify_member(member: discord.Member, rsi_handle: str, bot) -> tuple:
+    """Re-check a member's roles based on their RSI handle."""
+    from verification.rsi_verification import is_valid_rsi_handle
+
+    verify_value, cased_handle = await is_valid_rsi_handle(rsi_handle, bot.http_client)
+    if verify_value is None or cased_handle is None:
+        return False, "unknown", "Failed to verify RSI handle."
+
+    role_type = await assign_roles(member, verify_value, cased_handle, bot)
+    return True, role_type, None

--- a/helpers/views.py
+++ b/helpers/views.py
@@ -112,6 +112,14 @@ class VerificationView(View):
         self.verify_button.callback = self.verify_button_callback
         self.add_item(self.verify_button)
 
+        self.recheck_button = Button(
+            label="Re-Check",
+            style=discord.ButtonStyle.secondary,
+            custom_id="verification_recheck_button"
+        )
+        self.recheck_button.callback = self.recheck_button_callback
+        self.add_item(self.recheck_button)
+
     async def get_token_button_callback(self, interaction: Interaction):
         """
         Callback for the 'Get Token' button.
@@ -155,6 +163,11 @@ class VerificationView(View):
 
         modal = HandleModal(self.bot)
         await interaction.response.send_modal(modal)
+
+    async def recheck_button_callback(self, interaction: Interaction):
+        verification_cog = self.bot.get_cog("verification")
+        if verification_cog:
+            await verification_cog.recheck_button(interaction)
 
 # -------------------------
 # Channel Settings + Permissions

--- a/migrations/003_add_last_recheck.sql
+++ b/migrations/003_add_last_recheck.sql
@@ -1,0 +1,1 @@
+ALTER TABLE verification ADD COLUMN last_recheck INTEGER DEFAULT 0;

--- a/tests/test_database_migration.py
+++ b/tests/test_database_migration.py
@@ -1,0 +1,42 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import asyncio
+import pytest
+import aiosqlite
+
+from helpers.database import Database
+
+@pytest.mark.asyncio
+async def test_create_tables_adds_last_recheck_when_missing():
+    async with aiosqlite.connect(":memory:") as db:
+        # simulate old schema without last_recheck column
+        await db.execute(
+            """
+            CREATE TABLE verification (
+                user_id INTEGER PRIMARY KEY,
+                rsi_handle TEXT NOT NULL,
+                membership_status TEXT NOT NULL,
+                last_updated INTEGER NOT NULL
+            )
+            """
+        )
+        await db.commit()
+
+        await Database._create_tables(db)
+
+        cursor = await db.execute("PRAGMA table_info(verification)")
+        columns = {row[1]: row[4] for row in await cursor.fetchall()}
+        assert "last_recheck" in columns
+        assert columns["last_recheck"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_create_tables_idempotent_on_new_db():
+    async with aiosqlite.connect(":memory:") as db:
+        await Database._create_tables(db)
+        await Database._create_tables(db)
+
+        cursor = await db.execute("PRAGMA table_info(verification)")
+        column_names = [row[1] for row in await cursor.fetchall()]
+        assert column_names.count("last_recheck") == 1
+


### PR DESCRIPTION
## Summary
- add helper for role-specific welcome descriptions
- expose Re-Check button in VerificationView
- implement recheck logic with cooldown and DB persistence
- support recheck cooldown config
- create DB migration for last_recheck timestamp
- add idempotent check when altering verification table
- test database migration for last_recheck

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68692baafc288333bd64e40a68fa6598