### PR TITLE
96 add recheck user admin command to manually trigger verification recheck

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -205,7 +205,7 @@ class MyBot(commands.Bot):
         Applies slash command permissions so only 'bot_admins' or 'lead_moderators' can see/use certain commands.
         """
         # Define the restricted commands and combine role IDs
-        restricted_commands = ["reset-all", "reset-user", "status", "view-logs"]
+        restricted_commands = ["reset-all", "reset-user", "status", "view-logs", "recheck-user"]
         combined_role_ids = set(self.BOT_ADMIN_ROLE_IDS + self.LEAD_MODERATOR_ROLE_IDS)
 
         # Validate roles in the guild

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -161,6 +161,7 @@ class Admin(commands.Cog):
     @reset_all.error
     @reset_user.error
     @status.error
+    @recheck_user.error
     @view_logs.error
     async def admin_command_error(self, interaction: discord.Interaction, error):
         if isinstance(error, app_commands.errors.MissingAnyRole):

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -114,7 +114,6 @@ class Admin(commands.Cog):
     @app_commands.checks.has_any_role(*CONFIG['roles']['bot_admins'])
     @app_commands.guild_only()
     async def recheck_user(self, interaction: discord.Interaction, member: discord.Member):
-        logger = logging.getLogger(__name__)
         if member.guild.id != interaction.guild.id:
             await interaction.response.send_message(
                 f"{member.display_name} is not in this server.",

--- a/commands.txt
+++ b/commands.txt
@@ -23,4 +23,5 @@
 - **/voice reset** - Reset your channel settings to default.
 - **/voice claim** - Claim ownership of a voice channel if the original owner left.
 - **/voice help** - Show help for voice commands.
-- **/voice admin_reset [user]** - Admin command to reset a user's voice channel. Only for Bot Admins and Lead Moderators.- **/voice owner** - List all voice channels managed by the bot and their owners.
+- **/voice admin_reset [user]** - Admin command to reset a user's voice channel. Only for Bot Admins and Lead Moderators.
+- **/voice owner** - List all voice channels managed by the bot and their owners.

--- a/commands.txt
+++ b/commands.txt
@@ -7,6 +7,7 @@
 - **/reload-config** - Reload the bot's configuration. Only for Bot Admins.
 - **/status** - Check the status of the bot.
 - **/view-logs** - View recent bot logs. Bot Admins and Lead Moderators.
+- **/recheck-user [member]** – Manually trigger a verification re-check for a user. Bot Admins only; bypasses cooldown.
 
 ## Voice Commands
 
@@ -22,5 +23,4 @@
 - **/voice reset** - Reset your channel settings to default.
 - **/voice claim** - Claim ownership of a voice channel if the original owner left.
 - **/voice help** - Show help for voice commands.
-- **/voice admin_reset [user]** - Admin command to reset a user's voice channel. Only for Bot Admins and Lead Moderators.
-- **/voice owner** - List all voice channels managed by the bot and their owners.
+- **/voice admin_reset [user]** - Admin command to reset a user's voice channel. Only for Bot Admins and Lead Moderators.- **/voice owner** - List all voice channels managed by the bot and their owners.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,2 @@
+from .config_loader import ConfigLoader
+CONFIG = ConfigLoader.load_config()


### PR DESCRIPTION
## Summary by Sourcery

Add a new admin slash command to manually re-trigger user verification and integrate it into the existing permission system.

New Features:
- Introduce `/recheck-user` command for bot admins to force a verification re-check on a guild member

Enhancements:
- Include `recheck-user` in the list of restricted admin commands for permission setup

Chores:
- Add `config/__init__.py` to centralize loading of configuration values