### PR TITLE
Feature/verification moniker nickname sync

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: Run Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }} tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.python-version }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+          # Ensure core test/dev tools present (even if not pinned in requirements)
+          pip install pytest pytest-asyncio coverage
+
+      - name: Run tests
+        run: pytest -q

--- a/bot.py
+++ b/bot.py
@@ -35,10 +35,7 @@ if not TOKEN:
 # Access configuration values from config.yaml (kept at module scope so dev tools can import PREFIX safely)
 # Some deployments may accidentally supply an empty list / string; fall back to mention‑only behavior.
 raw_prefix = config["bot"].get("prefix")
-if not raw_prefix:  # empty list, empty string, None -> default
-    PREFIX = commands.when_mentioned
-else:
-    PREFIX = raw_prefix
+PREFIX = commands.when_mentioned if not raw_prefix else raw_prefix  # empty list, empty string, None -> default
 VERIFICATION_CHANNEL_ID = config["channels"]["verification_channel_id"]
 BOT_SPAM_CHANNEL_ID = config["channels"].get("bot_spam_channel_id")
 BOT_VERIFIED_ROLE_ID = config["roles"]["bot_verified_role_id"]

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -14,7 +14,10 @@ from helpers.token_manager import clear_token, clear_all_tokens
 from helpers.discord_api import send_message
 from helpers.database import Database
 from helpers.role_helper import reverify_member
-from helpers.announcement import send_verification_announcements
+from helpers.announcement import send_verification_announcements  # legacy (will be suppressed)
+from helpers.leadership_log import ChangeSet, EventType, post_if_changed
+from helpers.snapshots import snapshot_member_state, diff_snapshots
+from helpers.task_queue import flush_tasks
 from helpers.permissions_helper import (
     resolve_role_ids_for_guild,
     app_command_check_configured_roles,
@@ -233,6 +236,10 @@ class Admin(commands.Cog):
         from helpers.http_helper import NotFoundError
         from helpers.username_404 import handle_username_404
 
+        # Take snapshot BEFORE reverify so we can diff DB + nickname/roles changes correctly
+        import time as _t
+        _start = _t.time()
+        before_snap = await snapshot_member_state(self.bot, member)
         try:
             success, status_tuple, error_msg = await reverify_member(member, rsi_handle, self.bot)
         except NotFoundError:
@@ -260,14 +267,42 @@ class Admin(commands.Cog):
             new_status = status_tuple
 
         admin_display = interaction.user.display_name or interaction.user.name
-        await send_verification_announcements(
-            self.bot,
-            member,
-            old_status,
-            new_status,
-            is_recheck=True,
-            by_admin=admin_display,
+        # Leadership snapshot diff (after roles/nick tasks flushed)
+        try:
+            await flush_tasks()
+        except Exception:
+            pass
+        # Attempt to refetch member to ensure updated nickname/roles reflected
+        try:
+            refreshed = await member.guild.fetch_member(member.id)
+            if refreshed:
+                member = refreshed
+        except Exception:
+            pass
+        after_snap = await snapshot_member_state(self.bot, member)
+        diff = diff_snapshots(before_snap, after_snap)
+        # Fallback: if no username diff but nickname task queued, use preferred nick
+        try:
+            if diff.get('username_before') == diff.get('username_after') and getattr(member, '_nickname_changed_flag', False):
+                pref = getattr(member, '_preferred_verification_nick', None)
+                if pref and pref != diff.get('username_before'):
+                    diff['username_after'] = pref
+        except Exception:
+            pass
+        cs = ChangeSet(
+            user_id=member.id,
+            event=EventType.ADMIN_CHECK,
+            initiator_kind='Admin',
+            initiator_name=admin_display,
+            notes=None,
         )
+        for k, v in diff.items():
+            setattr(cs, k, v)
+    # duration tracking removed
+        try:
+            await post_if_changed(self.bot, cs)
+        except Exception:
+            logger.debug("Leadership log post failed (admin recheck)")
 
         await interaction.followup.send(
             f"{member.display_name} is now **{new_status}** (was **{old_status}** on {date_str}).",

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -14,7 +14,6 @@ from helpers.token_manager import clear_token, clear_all_tokens
 from helpers.discord_api import send_message
 from helpers.database import Database
 from helpers.role_helper import reverify_member
-from helpers.announcement import send_verification_announcements  # legacy (will be suppressed)
 from helpers.leadership_log import ChangeSet, EventType, post_if_changed
 from helpers.snapshots import snapshot_member_state, diff_snapshots
 from helpers.task_queue import flush_tasks

--- a/cogs/recheck.py
+++ b/cogs/recheck.py
@@ -111,10 +111,10 @@ class AutoRecheck(commands.Cog):
     ) -> None:
         try:
             # Validate handle and fetch current status
-            verify_value, cased_handle = await is_valid_rsi_handle(
+            verify_value, cased_handle, community_moniker = await is_valid_rsi_handle(
                 rsi_handle, self.bot.http_client
             )
-            if verify_value is None or cased_handle is None:
+            if verify_value is None or cased_handle is None:  # moniker optional
                 # Transient fetch/parse failure: schedule backoff
                 current_fc = await Database.get_auto_recheck_fail_count(int(user_id))
                 delay = self._compute_backoff(fail_count=(current_fc or 0) + 1)
@@ -126,10 +126,13 @@ class AutoRecheck(commands.Cog):
                     inc=True,
                 )
                 return
-
-                # Apply roles; get (old_status, new_status)
+            # Apply roles; get (old_status, new_status)
             old_status, new_status = await assign_roles(
-                member, verify_value, cased_handle, self.bot
+                member,
+                verify_value,
+                cased_handle,
+                self.bot,
+                community_moniker=community_moniker,
             )
 
             # Announce only if membership status changed

--- a/cogs/recheck.py
+++ b/cogs/recheck.py
@@ -12,7 +12,6 @@ from helpers.database import Database
 from verification.rsi_verification import is_valid_rsi_handle
 from helpers.http_helper import NotFoundError
 from helpers.role_helper import assign_roles
-from helpers.announcement import send_verification_announcements  # legacy
 from helpers.leadership_log import ChangeSet, EventType, post_if_changed
 from helpers.snapshots import snapshot_member_state, diff_snapshots
 from helpers.task_queue import flush_tasks

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -18,7 +18,6 @@ from helpers.logger import get_logger
 from helpers.discord_api import followup_send_message
 from helpers.role_helper import reverify_member
 from helpers.rate_limiter import check_rate_limit, log_attempt
-from helpers.announcement import send_verification_announcements  # legacy
 from helpers.http_helper import NotFoundError
 from helpers.username_404 import handle_username_404
 from helpers.leadership_log import ChangeSet, EventType, post_if_changed
@@ -166,9 +165,9 @@ class VerificationCog(commands.Cog):
             return
 
         if isinstance(status_info, tuple):
-            old_status, new_status = status_info
+            _old_status, new_status = status_info
         else:
-            old_status = new_status = status_info
+            new_status = status_info
 
         await log_attempt(member.id, "recheck")
 

--- a/docs/verification_workflow.md
+++ b/docs/verification_workflow.md
@@ -10,7 +10,7 @@ It also highlights where a future **Re‑Check** feature would integrate.
   1. RSI handle format.
   2. Membership in the TEST organization via [`is_valid_rsi_handle`](../verification/rsi_verification.py).
   3. That a valid token exists and is present in the user’s RSI bio via [`is_valid_rsi_bio`](../verification/rsi_verification.py).
-- **Role Assignment**: If checks succeed, [`assign_roles`](../helpers/role_helper.py) grants `BotVerified` plus the appropriate org role (Main/Affiliate/Non‑Member). Verification attempts and tokens are cleared.
+- **Role Assignment & Moniker Sync**: If checks succeed, [`assign_roles`](../helpers/role_helper.py) grants `BotVerified` plus the appropriate org role (Main/Affiliate/Non‑Member). The user's RSI Community Moniker (if parsable and distinct from the handle) is stored and their Discord nickname is updated to match (truncated with an ellipsis if over 32 characters). Future auto re‑checks refresh this moniker and update the nickname if it changes.
 - **Rate Limiting**: All verification actions are limited by [`check_rate_limit`](../helpers/rate_limiter.py). Exceeding the limit sends a cooldown embed.
 
 ## Where Re‑Check Fits

--- a/helpers/database.py
+++ b/helpers/database.py
@@ -68,9 +68,13 @@ class Database:
                 )
                 logger.info("Added column verification.needs_reverify")
             except sqlite3.OperationalError as e:
-                logger.warning(f"Could not add needs_reverify column (maybe already exists): {e}")
+                logger.warning(
+                    f"Could not add needs_reverify column (maybe already exists): {e}"
+                )
             except Exception as e:
-                logger.error(f"Unexpected error adding needs_reverify column: {e}")
+                logger.error(
+                    f"Unexpected error adding needs_reverify column: {e}"
+                )
         if "needs_reverify_at" not in columns:
             try:
                 await db.execute(
@@ -78,9 +82,28 @@ class Database:
                 )
                 logger.info("Added column verification.needs_reverify_at")
             except sqlite3.OperationalError as e:
-                logger.warning(f"Could not add needs_reverify_at column (maybe already exists): {e}")
+                logger.warning(
+                    f"Could not add needs_reverify_at column (maybe already exists): {e}"
+                )
             except Exception as e:
-                logger.error(f"Unexpected error adding needs_reverify_at column: {e}")
+                logger.error(
+                    f"Unexpected error adding needs_reverify_at column: {e}"
+                )
+        if "community_moniker" not in columns:
+            try:
+                await db.execute(
+                    "ALTER TABLE verification ADD COLUMN community_moniker TEXT"
+                )
+                logger.info("Added column verification.community_moniker")
+            except sqlite3.OperationalError as e:
+                logger.warning(
+                    f"Could not add community_moniker column (maybe already exists): {e}"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Unexpected error adding community_moniker column: {e}"
+                )
+
         if last_recheck_exists:
             logger.info("Found legacy last_recheck column; will migrate data.")
 
@@ -424,7 +447,7 @@ class Database:
             )
             return await cursor.fetchall()
 
-    # 404 username change helpers
+    # 404 handle change helpers (legacy 'username_404' module name retained for backward compatibility)
     @classmethod
     async def flag_needs_reverify(cls, user_id: int, now: int) -> bool:
         """Set needs_reverify flag. Returns True if row updated (was newly flagged)."""

--- a/helpers/embeds.py
+++ b/helpers/embeds.py
@@ -87,10 +87,10 @@ def create_token_embed(token: str, expires_unix: int) -> discord.Embed:
     )
 
     embed.set_footer(
-            text=(
-                "By verifying, you consent to storing your RSI handle and verification "
-                "status for role assignment purposes."
-            )
+        text=(
+            "By verifying, you consent to storing your RSI handle, community moniker (if found), "
+            "and verification status for role assignment and username syncing."
+        )
     )
 
     return embed

--- a/helpers/embeds.py
+++ b/helpers/embeds.py
@@ -157,7 +157,7 @@ def create_cooldown_embed(wait_until: int) -> discord.Embed:
 def build_welcome_description(role_type: str) -> str:
     """Return a role-specific welcome message."""
     if role_type == "main":
-        return (
+        base = (
             "<:testSquad:1332572066804928633> **Welcome, to TEST Squadron - "
             "Best Squadron!** <:BESTSquad:1332572087524790334>\n\n"
             "We're thrilled to have you as a MAIN member of **TEST Squadron!**\n\n"
@@ -165,8 +165,9 @@ def build_welcome_description(role_type: str) -> str:
             "make the most of your experience!\n\n"
             "Fly safe! <:o7:1332572027877593148>"
         )
+        return base + "\n\nWe set your Discord username to your RSI moniker if available; otherwise we use your RSI handle."
     if role_type == "affiliate":
-        return (
+        base = (
             "<:testSquad:1332572066804928633> **Welcome, to TEST Squadron - "
             "Best Squadron!** <:BESTSquad:1332572087524790334>\n\n"
             "Your support helps us grow and excel. We encourage you to set **TEST** as "
@@ -178,8 +179,9 @@ def build_welcome_description(role_type: str) -> str:
             "involved!\n\n"
             "<:o7:1332572027877593148>"
         )
+        return base + "\n\nWe set your Discord username to your RSI moniker if available; otherwise we use your RSI handle."
     if role_type == "non_member":
-        return (
+        base = (
             "<:testSquad:1332572066804928633> **Welcome, to TEST Squadron - "
             "Best Squadron!** <:BESTSquad:1332572087524790334>\n\n"
             "It looks like you're not yet a member of our org. <:what:1332572046638452736>\n\n"
@@ -190,4 +192,5 @@ def build_welcome_description(role_type: str) -> str:
             "Join our voice chats, explore events, and engage in our text channels to get "
             "involved! <:o7:1332572027877593148>"
         )
-    return "Welcome to the server! You can verify again after 3 hours if needed."
+        return base + "\n\nWe set your Discord username to your RSI moniker if available; otherwise we use your RSI handle."
+    return "Welcome to the server! You can verify again after 3 hours if needed. We set your Discord username to your RSI moniker if available; otherwise we use your RSI handle."

--- a/helpers/handle_404.py
+++ b/helpers/handle_404.py
@@ -1,0 +1,2 @@
+# Temporary shim for legacy imports — remove once all refs are migrated
+from .username_404 import *  # noqa: F401,F403

--- a/helpers/leadership_log.py
+++ b/helpers/leadership_log.py
@@ -1,0 +1,448 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from datetime import datetime, timezone
+from typing import List, Optional, Literal, Tuple, Dict
+import time
+
+import discord  # NOTE: legacy embed support retained for backward compat in older tests; new flow uses plain text
+
+from helpers.logger import get_logger
+from helpers.discord_api import channel_send_message
+
+logger = get_logger(__name__)
+
+
+class EventType(str, Enum):
+    VERIFICATION = "VERIFICATION"  # User initial verification ("User Verify")
+    RECHECK = "RECHECK"            # User initiated re-check via button
+    AUTO_CHECK = "AUTO_CHECK"      # Scheduled automatic re-check
+    ADMIN_CHECK = "ADMIN_CHECK"    # Admin initiated manual check
+
+
+@dataclass
+class ChangeSet:
+    user_id: int
+    event: EventType
+    initiator_kind: Literal['User','Admin','Auto']
+    initiator_name: Optional[str] = None
+
+    status_before: Optional[str] = None
+    status_after: Optional[str] = None
+    moniker_before: Optional[str] = None
+    moniker_after: Optional[str] = None
+    handle_before: Optional[str] = None
+    handle_after: Optional[str] = None
+    username_before: Optional[str] = None
+    username_after: Optional[str] = None
+
+    roles_added: List[str] = field(default_factory=list)   # retained for compatibility but no longer rendered
+    roles_removed: List[str] = field(default_factory=list) # retained for compatibility but no longer rendered
+
+    notes: Optional[str] = None
+    started_at: datetime = field(default_factory=datetime.utcnow)
+    duration_ms: int = 0
+
+
+MD_ESCAPE_CHARS = ['`', '*', '_', '~', '|', '>', '\\']
+
+# In‑memory short window dedupe store: (user_id, signature) -> last_post_ts
+_DEDUP_CACHE: Dict[Tuple[int, str], float] = {}
+_DEDUP_TTL_SECONDS = 20  # within 20s identical change suppressed
+
+
+def escape_md(value: str) -> str:
+    if value is None:
+        return ''
+    out = []
+    for ch in value:
+        if ch in MD_ESCAPE_CHARS:
+            out.append('\\' + ch)
+        else:
+            out.append(ch)
+    return f"`{''.join(out)}`"
+
+
+def _changed(a: Optional[str], b: Optional[str]) -> bool:
+    return (a or '') != (b or '')
+
+
+def _changed_case_sensitive(a: Optional[str], b: Optional[str]) -> bool:
+    """Case sensitive change check used for rendering sections.
+    Noise suppression (case only) handled in higher-level suppression logic."""
+    return (a or '') != (b or '')
+
+
+def _changed_material(a: Optional[str], b: Optional[str]) -> bool:
+    """Material textual change ignoring case only differences."""
+    return (a or '').lower() != (b or '').lower()
+
+
+def _managed_role_names(bot) -> List[str]:  # pragma: no cover (trivial helper)
+    names = []
+    keys = [
+        'BOT_VERIFIED_ROLE_ID',
+        'MAIN_ROLE_ID',
+        'AFFILIATE_ROLE_ID',
+        'NON_MEMBER_ROLE_ID',
+    ]
+    for k in keys:
+        rid = getattr(bot, k, None)
+        if not rid:
+            continue
+        role = getattr(bot, 'role_cache', {}).get(rid)
+        if role is None:
+            # Attempt guild fetch fallback (first guild assumed)
+            try:
+                guild = bot.guilds[0]
+                role = guild.get_role(rid)
+            except Exception:
+                role = None
+        if role:
+            names.append(getattr(role, 'name', str(role)))
+    return names
+
+
+def is_effectively_unchanged(cs: ChangeSet, bot=None) -> bool:
+    """Return True when there is no material change to report.
+
+    Suppress:
+      - Case-only moniker / nickname / handle changes
+      - Pure role order permutations (we only consider managed role set + added/removed lists)
+      - Non-managed role churn (we filter roles before populating ChangeSet)
+    Always post if notes contain error/404/override semantics.
+    """
+    if cs.notes:
+        lower = cs.notes.lower()
+        if any(k in lower for k in ["error", "fail", "404", "override"]):
+            return False
+
+    # Material textual changes (case-insensitive)
+    textual = any([
+        _changed_material(cs.status_before, cs.status_after),
+        _changed_material(cs.moniker_before, cs.moniker_after),
+        _changed_material(cs.handle_before, cs.handle_after),
+        _changed_material(cs.username_before, cs.username_after),
+    ])
+
+    role_diff = bool(cs.roles_added or cs.roles_removed)
+    # If only case differences, treat as unchanged.
+    if not textual and not role_diff:
+        return True
+    return False
+
+
+def color_for(cs: ChangeSet) -> int:
+    # Discord color ints (approx): green, yellow, red, blurple
+    GREEN = 0x2ecc71
+    YELLOW = 0xf1c40f
+    RED = 0xe74c3c
+    BLURPLE = 0x5865F2
+
+    if cs.notes and any(k in cs.notes.lower() for k in ["error", "fail", "404"]):
+        return RED
+
+    if _changed(cs.status_before, cs.status_after):
+        # Promotion/demotion (treat Main/Affiliate/Verified variants equivalently)
+        after = (cs.status_after or '').lower()
+        before = (cs.status_before or '').lower()
+        verified_set = {'verified', 'main', 'affiliate'}
+        if after in verified_set and before not in verified_set:
+            return GREEN
+        if after == 'not a member' and before in verified_set:
+            return RED
+        return YELLOW
+
+    if cs.roles_added and not cs.roles_removed:
+        return GREEN
+    if cs.roles_removed and not cs.roles_added:
+        return YELLOW
+    if cs.roles_added or cs.roles_removed:
+        return YELLOW
+
+    # Only moniker/handle changes => informational
+    if _changed(cs.moniker_before, cs.moniker_after) or _changed(cs.handle_before, cs.handle_after):
+        return BLURPLE
+
+    return BLURPLE
+
+
+def _event_title(ev: EventType) -> str:
+    return {
+        EventType.VERIFICATION: "Verification",
+        EventType.RECHECK: "Recheck",
+        EventType.AUTO_CHECK: "Auto Check",
+        EventType.ADMIN_CHECK: "Admin Check",
+    }.get(ev, ev.value)
+
+
+def build_message(bot, cs: ChangeSet) -> str:
+    """Return the new plain‑text leadership log message.
+
+    This is the core renderer used by post_if_changed. It purposefully ignores the
+    previously used embed layout while keeping a simplified interface so existing
+    callers (tests) that invoked build_message still succeed.
+    """
+    return _render_plaintext(cs)
+
+
+def _event_emoji(cs: ChangeSet) -> str:
+    if cs.notes and cs.notes and '404' in cs.notes.lower():
+        return '⚠️'
+    return {
+        EventType.ADMIN_CHECK: '🧑‍✈️',
+        EventType.VERIFICATION: '✅',
+        EventType.RECHECK: '🔁',
+        EventType.AUTO_CHECK: '🤖',
+    }.get(cs.event, '🗂️')
+
+
+def _verbosity(bot) -> str:
+    try:
+        return ((bot.config or {}).get('leadership_log', {}) or {}).get('verbosity', 'normal').lower()
+    except Exception:
+        return 'normal'
+
+
+def _normalize_signature(cs: ChangeSet) -> str:
+    parts = [
+        cs.status_before or '', cs.status_after or '',
+        (cs.moniker_before or '').lower(), (cs.moniker_after or '').lower(),
+        (cs.handle_before or '').lower(), (cs.handle_after or '').lower(),
+        (cs.username_before or '').lower(), (cs.username_after or '').lower(),
+        '|'.join(sorted([r.lower() for r in cs.roles_added])) if cs.roles_added else '',
+        '|'.join(sorted([r.lower() for r in cs.roles_removed])) if cs.roles_removed else '',
+        (cs.notes or '').lower(),
+        cs.event.value,
+    ]
+    return '§'.join(parts)
+
+
+def build_embed(bot, cs: ChangeSet) -> discord.Embed:
+    """Create the structured leadership log embed per specification."""
+    emoji = _event_emoji(cs)
+    duration = ''  # duration tracking removed
+    title = f"🗂️ <@{cs.user_id}> — Verification Update"
+    header_initiated = f"Initiated by {cs.initiator_kind}" + (f" ({cs.initiator_name})" if cs.initiator_kind == 'Admin' and cs.initiator_name else '')
+    embed = discord.Embed(title=title, color=color_for(cs))
+    embed.description = f"{emoji} {_event_title(cs.event)} • {header_initiated}{duration}"
+
+    def add_section(label: str, before: Optional[str], after: Optional[str]):
+        if _changed_material(before, after):
+            embed.add_field(name=label, value=f"{before or '—'} → {after or '—'}", inline=False)
+        elif _verbosity(bot) == 'verbose':
+            # In verbose mode show unchanged chips
+            if before:
+                embed.add_field(name=label, value=f"No Change ({before})", inline=False)
+
+    add_section('Membership Status', cs.status_before, cs.status_after)
+    add_section('RSI Handle', cs.handle_before, cs.handle_after)
+    add_section('Community Moniker', cs.moniker_before, cs.moniker_after)
+    add_section('Discord Nickname', cs.username_before, cs.username_after)
+
+    if cs.roles_added:
+        embed.add_field(name='Roles Added', value='\n'.join(f"• {r}" for r in cs.roles_added), inline=False)
+    if cs.roles_removed:
+        embed.add_field(name='Roles Removed', value='\n'.join(f"• {r}" for r in cs.roles_removed), inline=False)
+
+    if cs.notes:
+        embed.add_field(name='Notes', value=cs.notes, inline=False)
+
+    # Footer
+    handle = cs.handle_after or cs.handle_before or 'No Handle'
+    timestamp = datetime.utcnow().replace(tzinfo=timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
+    footer_text = f"{cs.user_id} • {handle} • {timestamp}"
+    if handle and handle != 'No Handle':
+        try:
+            embed.url = f"https://robertsspaceindustries.com/citizens/{handle}"
+        except Exception:  # pragma: no cover
+            pass
+    embed.set_footer(text=footer_text)
+    return embed
+
+
+def _summarize_roles(added: list[str], removed: list[str]) -> Optional[str]:  # legacy stub
+    return None
+
+
+def _truncate(value: Optional[str], length: int = 32) -> Optional[str]:
+    if value is None:
+        return None
+    v = value.strip()
+    if len(v) <= length:
+        return v
+    return v[: length - 1] + '…'
+
+
+_MD_INLINE = set(['`','*','_','~','|','>'])
+
+
+def _escape_inline(value: Optional[str]) -> str:
+    if value is None:
+        return ''
+    out = []
+    for ch in value:
+        if ch in _MD_INLINE:
+            out.append('\\' + ch)
+        else:
+            out.append(ch)
+    return ''.join(out)
+
+
+def _action_tag(cs: ChangeSet) -> str:
+    return {
+        EventType.VERIFICATION: 'User Verify',
+        EventType.RECHECK: 'Admin Check' if cs.initiator_kind == 'Admin' and cs.event == EventType.RECHECK else 'Admin Check' if cs.event == EventType.ADMIN_CHECK else 'User Verify' if cs.event == EventType.RECHECK and cs.initiator_kind == 'User' else 'Auto Re-check' if cs.event == EventType.AUTO_CHECK else 'Admin Check' if cs.event == EventType.ADMIN_CHECK else cs.event.name,
+        EventType.AUTO_CHECK: 'Auto Re-check',
+        EventType.ADMIN_CHECK: 'Admin Check',
+    }[cs.event]
+
+
+def _outcome_and_emoji(cs: ChangeSet, changed_fields: int, had_changes: bool, first_verify: bool) -> tuple[str, str]:
+    if not had_changes:
+        return ('No changes', '🔎')
+    if first_verify and cs.event == EventType.VERIFICATION:
+        return ('Verified', '✅')
+    return ('Updated', '🔁')
+
+
+def _build_header(cs: ChangeSet, changed_fields: int, had_changes: bool) -> str:
+    first_verify = cs.event == EventType.VERIFICATION and _changed_material(cs.status_before, cs.status_after)
+    outcome, emoji = _outcome_and_emoji(cs, changed_fields, had_changes, first_verify)
+    tag = _action_tag(cs)
+    admin_part = ''
+    if tag in ('Admin Check',) and cs.initiator_kind == 'Admin' and cs.initiator_name:
+        admin_part = f" • Admin: {escape_md(_truncate(cs.initiator_name))}".replace('`','')  # header not code‑wrapped
+    return f"[{tag}{admin_part}] <@{cs.user_id}> {emoji} {outcome}"
+
+
+def _format_duration(ms: int) -> str:  # legacy stub (kept for compatibility)
+    return ''
+
+
+def _field_label_map() -> dict:
+    return {
+        'status': 'Status',
+        'moniker': 'Moniker',
+        'username': 'Nickname',
+        'handle': 'Handle',
+    }
+
+
+def _render_plaintext(cs: ChangeSet) -> str:
+    # Determine which fields changed materially
+    changes = []
+    if _changed_material(cs.status_before, cs.status_after):
+        changes.append(('Status', _escape_inline(_truncate(cs.status_before or 'Non-Member')), _escape_inline(_truncate(cs.status_after or 'Non-Member'))))
+    if _changed_material(cs.moniker_before, cs.moniker_after):
+        changes.append(('Moniker', _escape_inline(_truncate(cs.moniker_before or '(none)')), _escape_inline(_truncate(cs.moniker_after or '(none)'))))
+    if _changed_material(cs.username_before, cs.username_after):
+        changes.append(('Nickname', _escape_inline(_truncate(cs.username_before or '(none)')), _escape_inline(_truncate(cs.username_after or '(none)'))))
+    if _changed_material(cs.handle_before, cs.handle_after):
+        changes.append(('Handle', _escape_inline(_truncate(cs.handle_before or '(none)')), _escape_inline(_truncate(cs.handle_after or '(none)'))))
+    # Roles intentionally omitted from rendered output
+
+    had_changes = bool(changes)
+    header = _build_header(cs, len(changes), had_changes)
+
+    duration_line = None
+    if not had_changes:
+        # Only for admin or user initiated checks we still post (handled by caller) with no change line
+        return header
+
+    # Single-line compact fallback (only exactly one changed field & not status promotion demotion complexity)
+    if len(changes) == 1:
+        label, before, after = changes[0]
+        field_text = f"Roles: {after}" if label == 'Roles' else f"{label}: {before} → {after}"
+        if cs.event == EventType.AUTO_CHECK:
+            return f"[{_action_tag(cs)}] <@{cs.user_id}> 🔁 {field_text}"
+        return f"{header}\n{field_text}"
+
+    lines = [header]
+    for label, before, after in changes:
+        if label == 'Roles':
+            lines.append(f"Roles: {after}")
+        else:
+            lines.append(f"{label}: {before} → {after}")
+    if duration_line:
+        lines.append(duration_line)
+    return '\n'.join(lines)
+
+
+async def post_if_changed(bot, cs: ChangeSet):
+    # Normalize roles to managed set only; discard others for change signature & rendering
+    managed_names = set(_managed_role_names(bot))
+    if cs.roles_added:
+        cs.roles_added = [r for r in cs.roles_added if r in managed_names]
+    if cs.roles_removed:
+        cs.roles_removed = [r for r in cs.roles_removed if r in managed_names]
+
+    # Filter out case-only changes by rewriting after values to before when only case differs
+    for attr_pair in [('moniker_before', 'moniker_after'), ('username_before', 'username_after'), ('handle_before', 'handle_after')]:
+        b = getattr(cs, attr_pair[0])
+        a = getattr(cs, attr_pair[1])
+        if b and a and b.lower() == a.lower() and b != a:
+            setattr(cs, attr_pair[1], b)  # revert to suppress
+
+    unchanged = is_effectively_unchanged(cs, bot=bot)
+
+    # Decide posting logic per new spec
+    if cs.event == EventType.AUTO_CHECK and unchanged:
+        return  # suppress
+    if unchanged and cs.event in (EventType.RECHECK, EventType.ADMIN_CHECK):
+        # We still post a "No changes" line
+        pass
+
+    if cs.event == EventType.VERIFICATION:
+        # Always post
+        pass
+    if cs.event == EventType.RECHECK and cs.initiator_kind == 'User':
+        # user recheck (button) -> treat as User Verify tag? spec says header tags: User Verify, Admin Check, Auto Re-check
+        # We'll map to Admin Check only when initiator is Admin. Keep default mapping path (User Verify) in _action_tag for first verify only.
+        pass
+
+    # Dedupe short window
+    sig = _normalize_signature(cs)
+    key = (cs.user_id, sig)
+    now = time.time()
+    # Purge expired keys opportunistically
+    if len(_DEDUP_CACHE) > 1000:  # safety bound
+        expired = [k for k,v in _DEDUP_CACHE.items() if now - v > _DEDUP_TTL_SECONDS]
+        for k in expired:
+            _DEDUP_CACHE.pop(k, None)
+    last = _DEDUP_CACHE.get(key)
+    if last and now - last < _DEDUP_TTL_SECONDS:
+        logger.debug('Leadership log deduped identical ChangeSet within window.')
+        return
+    _DEDUP_CACHE[key] = now
+
+    # Channel resolution
+    channel_id = None
+    try:
+        channel_id = (bot.config or {}).get('channels', {}).get('leadership_announcement_channel_id')
+        if not channel_id and hasattr(bot, 'LEADERSHIP_LOG_CHANNEL_ID'):
+            channel_id = getattr(bot, 'LEADERSHIP_LOG_CHANNEL_ID')
+    except Exception:
+        channel_id = getattr(bot, 'LEADERSHIP_LOG_CHANNEL_ID', None)
+    if not channel_id:
+        logger.debug('Leadership log channel not configured; skipping post.')
+        return
+    channel = bot.get_channel(int(channel_id)) if channel_id else None
+    if not channel:
+        logger.debug('Leadership log channel object not found; skipping.')
+        return
+    try:
+        content = _render_plaintext(cs)
+        await channel_send_message(channel, content, embed=None)  # plain text only now
+    except Exception as e:
+        logger.warning(f"Failed posting leadership log: {e}")
+
+
+__all__ = [
+    'EventType',
+    'ChangeSet',
+    'escape_md',
+    'is_effectively_unchanged',
+    'color_for',
+    'build_message', 'build_embed',  # build_embed retained for backwards compatibility (may be removed later)
+    'post_if_changed',
+]

--- a/helpers/leadership_log.py
+++ b/helpers/leadership_log.py
@@ -252,8 +252,19 @@ def build_embed(bot, cs: ChangeSet) -> discord.Embed:
 
     # Footer
     handle = cs.handle_after or cs.handle_before or 'No Handle'
-    # Use timezone-aware UTC datetime for clarity
-    timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
+    # Use ChangeSet.started_at (when processing began) for consistent timing; fallback to current UTC
+    try:
+        started_at = getattr(cs, 'started_at', None)
+        if started_at:
+            if getattr(started_at, 'tzinfo', None) is None:
+                started_at = started_at.replace(tzinfo=timezone.utc)
+            else:
+                started_at = started_at.astimezone(timezone.utc)
+            timestamp = started_at.strftime('%Y-%m-%d %H:%M:%S UTC')
+        else:
+            timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
+    except Exception:
+        timestamp = 'Unknown'
     footer_text = f"{cs.user_id} • {handle} • {timestamp}"
     if handle and handle != 'No Handle':
         try:

--- a/helpers/role_helper.py
+++ b/helpers/role_helper.py
@@ -86,7 +86,7 @@ async def assign_roles(
                 rsi_handle = excluded.rsi_handle,
                 membership_status = excluded.membership_status,
                 last_updated = excluded.last_updated,
-                community_moniker = COALESCE(excluded.community_moniker, verification.community_moniker),
+                community_moniker = excluded.community_moniker,
                 -- Only clear needs_reverify if it was previously set (successful re-verification)
                 needs_reverify = CASE WHEN verification.needs_reverify = 1 THEN 0 ELSE verification.needs_reverify END,
                 needs_reverify_at = CASE WHEN verification.needs_reverify = 1 THEN NULL ELSE verification.needs_reverify_at END

--- a/helpers/role_helper.py
+++ b/helpers/role_helper.py
@@ -3,6 +3,7 @@
 import time
 import discord
 import random
+from typing import Optional
 
 from helpers.database import Database
 from helpers.logger import get_logger
@@ -29,7 +30,7 @@ async def assign_roles(
     verify_value: int,
     cased_handle: str,
     bot,
-    community_moniker: str | None = None,
+    community_moniker: Optional[str] = None,
 ):
     # Fetch previous status before DB update
     prev_status = None

--- a/helpers/snapshots.py
+++ b/helpers/snapshots.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from typing import Optional, Set, Dict, Any
+import discord
+
+from helpers.database import Database
+from helpers.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class MemberSnapshot:
+    status: str
+    moniker: Optional[str]  # community_moniker from DB
+    handle: Optional[str]   # rsi_handle from DB
+    username: Optional[str]  # discord nickname/display
+    roles: Set[str]  # Role names (non-managed filtered later)
+
+
+async def snapshot_member_state(bot, member: discord.Member) -> MemberSnapshot:
+    # Fetch DB state
+    status = 'Not a Member'
+    moniker = None
+    handle = None
+    try:
+        async with Database.get_connection() as db:
+            cur = await db.execute("SELECT membership_status, community_moniker, rsi_handle FROM verification WHERE user_id=?", (member.id,))
+            row = await cur.fetchone()
+            if row:
+                status_db, moniker_db, handle_db = row
+                # Map internal statuses to human terms for logs
+                mapping = {
+                    'main': 'Main',
+                    'affiliate': 'Affiliate',
+                    'non_member': 'Not a Member',
+                }
+                status = mapping.get(status_db, status_db or 'Not a Member')
+                moniker = moniker_db
+                handle = handle_db
+    except Exception as e:
+        logger.debug(f"Snapshot DB fetch failed for {member.id}: {e}")
+
+    username = member.display_name or getattr(member, 'name', None)
+    roles = set()
+    for r in getattr(member, 'roles', []) or []:
+        if not r:
+            continue
+        try:
+            if getattr(r, 'managed', False):
+                continue
+        except Exception:
+            pass
+        roles.add(getattr(r, 'name', str(r)))
+    return MemberSnapshot(status=status, moniker=moniker, handle=handle, username=username, roles=roles)
+
+
+def diff_snapshots(before: MemberSnapshot, after: MemberSnapshot) -> Dict[str, Any]:
+    roles_added = sorted(list(after.roles - before.roles))
+    roles_removed = sorted(list(before.roles - after.roles))
+    return {
+        'status_before': before.status,
+        'status_after': after.status,
+        'moniker_before': before.moniker,
+        'moniker_after': after.moniker,
+        'handle_before': before.handle,
+        'handle_after': after.handle,
+        'username_before': before.username,
+        'username_after': after.username,
+        'roles_added': roles_added,
+        'roles_removed': roles_removed,
+    }
+
+
+__all__ = ['MemberSnapshot', 'snapshot_member_state', 'diff_snapshots']

--- a/helpers/snapshots.py
+++ b/helpers/snapshots.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, Set, Dict, Any
+from typing import Optional, Set, Dict, Any, TypedDict, List
 import discord
 
 from helpers.database import Database
@@ -54,21 +54,34 @@ async def snapshot_member_state(bot, member: discord.Member) -> MemberSnapshot:
     return MemberSnapshot(status=status, moniker=moniker, handle=handle, username=username, roles=roles)
 
 
-def diff_snapshots(before: MemberSnapshot, after: MemberSnapshot) -> Dict[str, Any]:
-    roles_added = sorted(list(after.roles - before.roles))
-    roles_removed = sorted(list(before.roles - after.roles))
-    return {
-        'status_before': before.status,
-        'status_after': after.status,
-        'moniker_before': before.moniker,
-        'moniker_after': after.moniker,
-        'handle_before': before.handle,
-        'handle_after': after.handle,
-        'username_before': before.username,
-        'username_after': after.username,
-        'roles_added': roles_added,
-        'roles_removed': roles_removed,
-    }
+class MemberSnapshotDiff(TypedDict):
+    status_before: str
+    status_after: str
+    moniker_before: Optional[str]
+    moniker_after: Optional[str]
+    handle_before: Optional[str]
+    handle_after: Optional[str]
+    username_before: Optional[str]
+    username_after: Optional[str]
+    roles_added: List[str]
+    roles_removed: List[str]
 
 
-__all__ = ['MemberSnapshot', 'snapshot_member_state', 'diff_snapshots']
+def diff_snapshots(before: MemberSnapshot, after: MemberSnapshot) -> MemberSnapshotDiff:
+    roles_added: List[str] = sorted(list(after.roles - before.roles))
+    roles_removed: List[str] = sorted(list(before.roles - after.roles))
+    return MemberSnapshotDiff(
+        status_before=before.status,
+        status_after=after.status,
+        moniker_before=before.moniker,
+        moniker_after=after.moniker,
+        handle_before=before.handle,
+        handle_after=after.handle,
+        username_before=before.username,
+        username_after=after.username,
+        roles_added=roles_added,
+        roles_removed=roles_removed,
+    )
+
+
+__all__ = ['MemberSnapshot', 'MemberSnapshotDiff', 'snapshot_member_state', 'diff_snapshots']

--- a/helpers/username_404.py
+++ b/helpers/username_404.py
@@ -41,8 +41,11 @@ async def remove_bot_roles(member: discord.Member, bot):
     # Optimistically update member.roles immediately so test assertions observe removal
     try:
         member.roles = [r for r in member.roles if r not in roles_to_remove]
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(
+            f"Failed to optimistically update roles for {member.id}: {e}",
+            extra={"user_id": member.id},
+        )
 
     async def task():
         try:

--- a/helpers/username_404.py
+++ b/helpers/username_404.py
@@ -61,12 +61,9 @@ async def remove_bot_roles(member: discord.Member, bot):
 async def handle_username_404(bot, member: discord.Member, old_handle: str):
     """Unified, idempotent handler when an RSI Handle starts returning 404.
 
-    Legacy naming note:
-        Historically referred to as *username* 404. Module will be renamed
-        to handle_404 in future; keep import path for compatibility.
-        Terms:
-          - RSI Handle: unique identifier ("old_handle" here)
-          - Community Moniker: display name (not part of 404 detection)
+    Terms:
+        - RSI handle: unique identifier ("old_handle" here)
+        - Community moniker: display name (not part of 404 detection)
 
     Steps:
         1. Flag ``needs_reverify`` in DB (early exit if already flagged)

--- a/migrations/005_add_community_moniker.sql
+++ b/migrations/005_add_community_moniker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE verification ADD COLUMN community_moniker TEXT;

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+filterwarnings =
+	error::DeprecationWarning:helpers.*
+	ignore:.*audioop.*:DeprecationWarning
+	ignore:Deprecated call to `pkg_resources.declare_namespace`:DeprecationWarning
+	ignore::DeprecationWarning:discord.*
+	ignore::DeprecationWarning:bs4.*
+addopts = -ra

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,14 @@
 import asyncio
+import sys
+import os
 from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 from helpers.database import Database
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,16 @@
 import asyncio
 from types import SimpleNamespace
+import os
+import sys
 
 import pytest
 import pytest_asyncio
+
+# Ensure project root is on sys.path for CI environments where Python might
+# not automatically include it (e.g., some GitHub Actions runners invoking pytest differently).
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
 
 from helpers.database import Database
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,8 @@
 import asyncio
-import sys
-import os
 from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
-
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if ROOT_DIR not in sys.path:
-    sys.path.insert(0, ROOT_DIR)
 
 from helpers.database import Database
 

--- a/tests/test_is_valid_rsi_handle_moniker.py
+++ b/tests/test_is_valid_rsi_handle_moniker.py
@@ -22,3 +22,41 @@ async def test_is_valid_rsi_handle_returns_moniker(monkeypatch):
     assert verify_value == 1
     assert cased_handle == 'CaseHandle'
     assert moniker == 'Display Name'
+
+MISSING_MONIKER_PROFILE = '<div class="profile"><div class="info">\n<p class="entry"><span class="label">Handle name</span><strong class="value">CaseHandle</strong></p></div></div>'
+EMPTY_MONIKER_PROFILE = '<div class="profile"><div class="info">\n<p class="entry"><strong class="value">   </strong></p>\n<p class="entry"><span class="label">Handle name</span><strong class="value">CaseHandle</strong></p></div></div>'
+MALFORMED_PROFILE = '<html><div class="profile"><div class="info"><p class="entry"><span class="label">Handle name</span></p></div></div>'
+
+@pytest.mark.asyncio
+async def test_is_valid_rsi_handle_missing_moniker(monkeypatch):
+    http = FakeHTTP({
+        'https://robertsspaceindustries.com/citizens/TestUser/organizations': ORG_HTML,
+        'https://robertsspaceindustries.com/citizens/TestUser': MISSING_MONIKER_PROFILE,
+    })
+    verify_value, cased_handle, moniker = await rv.is_valid_rsi_handle('TestUser', http)
+    assert verify_value == 1
+    assert cased_handle == 'CaseHandle'
+    assert moniker is None
+
+@pytest.mark.asyncio
+async def test_is_valid_rsi_handle_empty_moniker(monkeypatch):
+    http = FakeHTTP({
+        'https://robertsspaceindustries.com/citizens/TestUser/organizations': ORG_HTML,
+        'https://robertsspaceindustries.com/citizens/TestUser': EMPTY_MONIKER_PROFILE,
+    })
+    verify_value, cased_handle, moniker = await rv.is_valid_rsi_handle('TestUser', http)
+    assert verify_value == 1
+    assert cased_handle == 'CaseHandle'
+    assert moniker is None
+
+@pytest.mark.asyncio
+async def test_is_valid_rsi_handle_malformed_profile(monkeypatch):
+    http = FakeHTTP({
+        'https://robertsspaceindustries.com/citizens/TestUser/organizations': ORG_HTML,
+        'https://robertsspaceindustries.com/citizens/TestUser': MALFORMED_PROFILE,
+    })
+    verify_value, cased_handle, moniker = await rv.is_valid_rsi_handle('TestUser', http)
+    # Handle should still be found (CaseHandle) absence due to malformed structure may null it
+    assert verify_value == 1
+    # cased_handle may be None if extraction fails gracefully
+    assert moniker is None

--- a/tests/test_is_valid_rsi_handle_moniker.py
+++ b/tests/test_is_valid_rsi_handle_moniker.py
@@ -1,0 +1,25 @@
+import pytest
+from types import SimpleNamespace
+from verification import rsi_verification as rv
+
+class FakeHTTP:
+    def __init__(self, pages):
+        self.pages = pages
+        self.calls = []
+    async def fetch_html(self, url):
+        self.calls.append(url)
+        return self.pages.get(url)
+
+ORG_HTML = '<div class="box-content org main visibility-V"><a class="value">TEST Squadron - Best Squardon!</a></div>'
+PROFILE_HTML = '<div class="profile"><div class="info">\n<p class="entry"><strong class="value">Display Name</strong></p>\n<p class="entry"><span class="label">Handle name</span><strong class="value">CaseHandle</strong></p></div></div>'
+
+@pytest.mark.asyncio
+async def test_is_valid_rsi_handle_returns_moniker(monkeypatch):
+    http = FakeHTTP({
+        'https://robertsspaceindustries.com/citizens/TestUser/organizations': ORG_HTML,
+        'https://robertsspaceindustries.com/citizens/TestUser': PROFILE_HTML,
+    })
+    verify_value, cased_handle, moniker = await rv.is_valid_rsi_handle('TestUser', http)
+    assert verify_value == 1
+    assert cased_handle == 'CaseHandle'
+    assert moniker == 'Display Name'

--- a/tests/test_is_valid_rsi_handle_moniker.py
+++ b/tests/test_is_valid_rsi_handle_moniker.py
@@ -1,5 +1,4 @@
 import pytest
-from types import SimpleNamespace
 from verification import rsi_verification as rv
 
 class FakeHTTP:

--- a/tests/test_leadership_log.py
+++ b/tests/test_leadership_log.py
@@ -46,7 +46,7 @@ async def test_auto_recheck_suppressed_when_no_change(monkeypatch):
     monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
     cs = ChangeSet(user_id=1, event=EventType.AUTO_CHECK, initiator_kind='Auto')
     await post_if_changed(bot, cs)
-    assert sent == []  # suppressed
+    assert not sent  # suppressed
 
 
 @pytest.mark.asyncio

--- a/tests/test_leadership_log.py
+++ b/tests/test_leadership_log.py
@@ -1,0 +1,186 @@
+import pytest
+from datetime import datetime
+
+from helpers.leadership_log import (
+    ChangeSet,
+    EventType,
+    post_if_changed,
+    escape_md,
+    build_message,
+    is_effectively_unchanged,
+)
+
+
+class DummyRole:
+    def __init__(self, role_id: int, name: str):
+        self.id = role_id
+        self.name = name
+
+
+class DummyBot:
+    def __init__(self):
+        self.config = {"channels": {"leadership_announcement_channel_id": 123}, "leadership_log": {"verbosity": "compact"}}
+        self._channel = object()
+        # Simulate managed roles (names used for filtering)
+        self.BOT_VERIFIED_ROLE_ID = 1001
+        self.MAIN_ROLE_ID = 1002
+        self.AFFILIATE_ROLE_ID = 1003
+        self.NON_MEMBER_ROLE_ID = 1004
+        self.role_cache = {
+            1001: DummyRole(1001, 'BotVerified'),
+            1002: DummyRole(1002, 'Member'),
+            1003: DummyRole(1003, 'Affiliate'),
+            1004: DummyRole(1004, 'Not a Member'),
+        }
+        self.guilds = []  # minimal for role lookup fallback
+
+    def get_channel(self, cid):
+        return self._channel if cid == 123 else None
+
+
+@pytest.mark.asyncio
+async def test_auto_recheck_suppressed_when_no_change(monkeypatch):
+    bot = DummyBot()
+    sent = []
+    async def fake_send(channel, content, embed=None):
+        sent.append(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
+    cs = ChangeSet(user_id=1, event=EventType.AUTO_CHECK, initiator_kind='Auto')
+    await post_if_changed(bot, cs)
+    assert sent == []  # suppressed
+
+
+@pytest.mark.asyncio
+async def test_user_verify_moniker_change(monkeypatch):
+    bot = DummyBot()
+    sent = []
+    async def fake_send(channel, content, embed=None):
+        sent.append(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
+    cs = ChangeSet(user_id=2, event=EventType.VERIFICATION, initiator_kind='User')
+    cs.moniker_before = '(none)'
+    cs.moniker_after = 'NewMoniker'
+    await post_if_changed(bot, cs)
+    assert len(sent) == 1
+    assert 'Moniker:' in sent[0]
+
+
+@pytest.mark.asyncio
+async def test_admin_recheck_handle_change(monkeypatch):
+    bot = DummyBot()
+    sent = []
+    async def fake_send(channel, content, embed=None):
+        sent.append(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
+    cs = ChangeSet(user_id=3, event=EventType.ADMIN_CHECK, initiator_kind='Admin', initiator_name='AdminX')
+    cs.handle_before = 'OldH'
+    cs.handle_after = 'NewH'
+    await post_if_changed(bot, cs)
+    assert len(sent) == 1
+    assert 'Handle: OldH → NewH' in sent[0]
+
+
+@pytest.mark.asyncio
+async def test_roles_diff_not_rendered(monkeypatch):
+    bot = DummyBot()
+    sent = []
+    async def fake_send(channel, content, embed=None):
+        sent.append(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
+    cs = ChangeSet(user_id=4, event=EventType.ADMIN_CHECK, initiator_kind='Admin', initiator_name='Adm')
+    cs.roles_added = ['Member']
+    cs.roles_removed = ['Affiliate']
+    await post_if_changed(bot, cs)
+    # No other field changed so this should be considered no-change and still post header (admin path)
+    assert len(sent) == 1
+    assert 'Roles:' not in sent[0]
+
+
+@pytest.mark.asyncio
+async def test_status_and_nickname_changes_multiline(monkeypatch):
+    bot = DummyBot()
+    sent = []
+    async def fake_send(channel, content, embed=None):
+        sent.append(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
+    cs = ChangeSet(user_id=5, event=EventType.ADMIN_CHECK, initiator_kind='Admin', initiator_name='Adm')
+    cs.status_before = 'Affiliate'
+    cs.status_after = 'Main'
+    cs.username_before = 'OldNick'
+    cs.username_after = 'NewNick'
+    await post_if_changed(bot, cs)
+    assert len(sent) == 1
+    assert 'Status: Affiliate → Main' in sent[0]
+    assert 'Nickname: OldNick → NewNick' in sent[0]
+
+
+@pytest.mark.asyncio
+async def test_no_change_admin_and_user_post(monkeypatch):
+    bot = DummyBot()
+    sent = []
+    async def fake_send(channel, content, embed=None):
+        sent.append(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
+    cs_admin = ChangeSet(user_id=10, event=EventType.ADMIN_CHECK, initiator_kind='Admin', initiator_name='Adm')
+    await post_if_changed(bot, cs_admin)
+    cs_user_recheck = ChangeSet(user_id=11, event=EventType.RECHECK, initiator_kind='User')
+    await post_if_changed(bot, cs_user_recheck)
+    assert len(sent) == 2
+    assert sent[0].endswith('No changes') or 'No changes' in sent[0]
+    assert sent[1]  # user recheck posts even without changes per spec
+
+
+def test_escape_md_prevents_markdown_injection():
+    raw = "*weird*_`test`"
+    esc = escape_md(raw)
+    assert esc.startswith('`') and esc.endswith('`')
+    assert '\\*' in esc and '\\_' in esc and '\\`' in esc
+
+
+@pytest.mark.asyncio
+async def test_case_only_moniker_change_user_recheck_posts_no_change(monkeypatch):
+    bot = DummyBot()
+    sent = []
+    async def fake_send(channel, content, embed=None):
+        sent.append(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
+    cs = ChangeSet(user_id=30, event=EventType.RECHECK, initiator_kind='User')
+    cs.moniker_before = 'Alpha'
+    cs.moniker_after = 'alpha'
+    await post_if_changed(bot, cs)
+    # Should show header only (no changes)
+    assert len(sent) == 1
+    assert 'Alpha → alpha' not in sent[0]
+    assert 'No changes' in sent[0]
+
+
+@pytest.mark.asyncio
+async def test_single_field_compact_auto(monkeypatch):
+    bot = DummyBot()
+    sent = []
+    async def fake_send(channel, content, embed=None):
+        sent.append(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
+    cs = ChangeSet(user_id=40, event=EventType.AUTO_CHECK, initiator_kind='Auto')
+    cs.moniker_before = 'Old'
+    cs.moniker_after = 'New'
+    await post_if_changed(bot, cs)
+    assert len(sent) == 1
+    # Single line expected for auto single change
+    assert '\n' not in sent[0]
+    assert 'Moniker:' in sent[0]
+
+
+@pytest.mark.asyncio
+async def test_dedupe(monkeypatch):
+    bot = DummyBot()
+    sent = []
+    async def fake_send(channel, content, embed=None):
+        sent.append(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', fake_send)
+    cs = ChangeSet(user_id=50, event=EventType.AUTO_CHECK, initiator_kind='Auto')
+    cs.handle_before = 'OldH'
+    cs.handle_after = 'NewH'
+    await post_if_changed(bot, cs)
+    await post_if_changed(bot, cs)
+    assert len(sent) == 1

--- a/tests/test_recheck_nickname_update.py
+++ b/tests/test_recheck_nickname_update.py
@@ -1,0 +1,111 @@
+import pytest
+import types
+
+from helpers.role_helper import assign_roles
+
+
+class FakeRole:
+    def __init__(self, rid, name):
+        self.id = rid
+        self.name = name
+
+
+class FakeGuild:
+    def __init__(self, owner_id, me_member):
+        self.owner_id = owner_id
+        self._me = me_member
+
+    @property
+    def me(self):  # bot member
+        return self._me
+
+    def get_role(self, rid):
+        return None
+
+
+class FakeBotMember:
+    def __init__(self, top_role_position=10):
+        self.top_role = types.SimpleNamespace(position=top_role_position)
+        self.guild_permissions = types.SimpleNamespace(manage_nicknames=True)
+
+
+class FakeMember:
+    def __init__(self, user_id, display_name, guild, roles=None, nick=None):
+        self.id = user_id
+        self.display_name = display_name
+        self.guild = guild
+        self.roles = roles or []
+        self.nick = nick
+
+
+@pytest.mark.asyncio
+async def test_assign_roles_updates_nickname_with_moniker(monkeypatch, temp_db):
+    # Prepare bot namespace
+    bot = types.SimpleNamespace()
+    bot.config = {}
+    # Role IDs
+    bot.BOT_VERIFIED_ROLE_ID = 1
+    bot.MAIN_ROLE_ID = 2
+    bot.AFFILIATE_ROLE_ID = 3
+    bot.NON_MEMBER_ROLE_ID = 4
+    bot.role_cache = {
+        1: FakeRole(1, "BotVerified"),
+        2: FakeRole(2, "Main"),
+        3: FakeRole(3, "Affiliate"),
+        4: FakeRole(4, "NonMember"),
+    }
+
+    # Fake guild/me/member
+    bot_member = FakeBotMember()
+    guild = FakeGuild(owner_id=5000, me_member=bot_member)
+    member = FakeMember(42, "Tester", guild, roles=[], nick=None)
+
+    # Patch role/nick dependency helpers
+    monkeypatch.setattr("helpers.role_helper.can_modify_nickname", lambda m: True)
+
+    # Capture edit_member calls
+    edits = {}
+
+    async def fake_edit_member(member_obj, **kwargs):
+        edits["nick"] = kwargs.get("nick")
+
+    monkeypatch.setattr("helpers.role_helper.edit_member", fake_edit_member)
+
+    async def immediate(task_fn):
+        await task_fn()
+
+    monkeypatch.setattr("helpers.role_helper.enqueue_task", lambda fn: immediate(fn))
+
+    # Initial assignment with moniker1
+    await assign_roles(member, 1, "CaseHandle", bot, community_moniker="Moniker One")
+    assert edits.get("nick") == "Moniker One"
+
+    # Second assignment with changed moniker
+    await assign_roles(member, 1, "CaseHandle", bot, community_moniker="Moniker Two")
+    assert edits.get("nick") == "Moniker Two"
+
+@pytest.mark.asyncio
+async def test_assign_roles_fallback_to_handle(monkeypatch, temp_db):
+    bot = types.SimpleNamespace()
+    bot.config = {}
+    bot.BOT_VERIFIED_ROLE_ID = 1
+    bot.MAIN_ROLE_ID = 2
+    bot.AFFILIATE_ROLE_ID = 3
+    bot.NON_MEMBER_ROLE_ID = 4
+    bot.role_cache = {1: FakeRole(1, "BotVerified"), 2: FakeRole(2, "Main"), 3: FakeRole(3, "Affiliate"), 4: FakeRole(4, "NonMember")}
+    bot_member = FakeBotMember()
+    guild = FakeGuild(owner_id=5000, me_member=bot_member)
+    member = FakeMember(43, "Tester2", guild, roles=[], nick=None)
+
+    monkeypatch.setattr("helpers.role_helper.can_modify_nickname", lambda m: True)
+
+    edits = {}
+    async def fake_edit_member(member_obj, **kwargs):
+        edits["nick"] = kwargs.get("nick")
+    monkeypatch.setattr("helpers.role_helper.edit_member", fake_edit_member)
+    async def immediate(task_fn):
+        await task_fn()
+    monkeypatch.setattr("helpers.role_helper.enqueue_task", lambda fn: immediate(fn))
+
+    await assign_roles(member, 1, "HandleCase", bot, community_moniker=None)
+    assert edits.get("nick") == "HandleCase"

--- a/tests/test_recheck_rate_limit.py
+++ b/tests/test_recheck_rate_limit.py
@@ -1,0 +1,13 @@
+import pytest
+from helpers.rate_limiter import check_rate_limit, log_attempt
+
+
+@pytest.mark.asyncio
+async def test_recheck_rate_limit_enforces_single_attempt(temp_db):
+    user_id = 999
+    limited, _ = await check_rate_limit(user_id, "recheck")
+    assert limited is False
+    await log_attempt(user_id, "recheck")
+    limited2, wait_until = await check_rate_limit(user_id, "recheck")
+    assert limited2 is True
+    assert wait_until > 0

--- a/tests/test_rsi_verification_moniker.py
+++ b/tests/test_rsi_verification_moniker.py
@@ -1,0 +1,25 @@
+import pytest
+from verification.rsi_verification import extract_moniker, _sanitize_moniker
+
+SAMPLE_HTML = '''<div class="profile"><div class="info">
+<p class="entry"><strong class="value">Cool Moniker</strong></p>
+<p class="entry"><span class="label">Handle name</span><strong class="value">CaseHandle</strong></p>
+</div></div>'''
+
+@pytest.mark.asyncio
+async def test_extract_moniker_parses_value_above_handle():
+    moniker = extract_moniker(SAMPLE_HTML, handle="CaseHandle")
+    assert moniker == "Cool Moniker"
+
+@pytest.mark.asyncio
+async def test_extract_moniker_skips_if_same_as_handle():
+    html = SAMPLE_HTML.replace("Cool Moniker", "CaseHandle")
+    moniker = extract_moniker(html, handle="CaseHandle")
+    assert moniker is None
+
+@pytest.mark.asyncio
+async def test_sanitize_truncates_control_chars():
+    raw = "C\u200bool\x00 Name"
+    cleaned = _sanitize_moniker(raw)
+    assert "\u200b" not in cleaned
+    assert "\x00" not in cleaned

--- a/tests/test_username_404_flow.py
+++ b/tests/test_username_404_flow.py
@@ -4,8 +4,6 @@ from unittest.mock import AsyncMock
 
 from helpers.database import Database
 from helpers.username_404 import handle_username_404
-from helpers import task_queue as tq
-from cogs.recheck import AutoRecheck
 from helpers.role_helper import reverify_member
 
 # --- Fixtures / fakes ---

--- a/tests/test_username_404_flow.py
+++ b/tests/test_username_404_flow.py
@@ -157,7 +157,7 @@ async def test_reverification_clears_needs_reverify(temp_db, monkeypatch):
 
     # Return successful verification
     async def fake_is_valid(_: str, __):
-        return 1, 'NewHandle'
+        return 1, 'NewHandle', None
     monkeypatch.setattr('verification.rsi_verification.is_valid_rsi_handle', fake_is_valid)
 
     ok, _role_type, _err = await reverify_member(member, 'OldOne', bot)

--- a/tests/test_username_404_flow.py
+++ b/tests/test_username_404_flow.py
@@ -86,17 +86,101 @@ async def test_handle_username_404_idempotent(temp_db, monkeypatch):
 
     # Validate only spam message now (leadership handled via standardized embed separately)
     assert send_mock.await_count == 1
-    spam_call = send_mock.await_args_list[0]
-    spam_msg = spam_call[0][1]
+
+@pytest.mark.asyncio
+async def test_handle_username_404_new_handle_reflags(temp_db, monkeypatch):
+    """Second call with DIFFERENT old handle should still process (distinct 404 cause)."""
+    async with Database.get_connection() as db:
+        await db.execute("INSERT INTO verification(user_id, rsi_handle, membership_status, last_updated) VALUES (?,?,?,?)", (111, 'FirstHandle', 'main', 1))
+        await db.commit()
+
+    bot = SimpleNamespace()
+    bot.BOT_VERIFIED_ROLE_ID = 1
+    bot.MAIN_ROLE_ID = 2
+    bot.AFFILIATE_ROLE_ID = 3
+    bot.NON_MEMBER_ROLE_ID = 4
+    bot.BOT_SPAM_CHANNEL_ID = 999
+    bot.VERIFICATION_CHANNEL_ID = 1234
+    bot.config = {"channels": {"leadership_announcement_channel_id": 555}}
+    role_cache = {
+        1: FakeRole(1, "BotVerified"),
+        2: FakeRole(2, "Main"),
+        3: FakeRole(3, "Affiliate"),
+        4: FakeRole(4, "NonMember"),
+    }
+    bot.role_cache = role_cache
+    member = FakeMember(uid=111)
+    member.roles = list(role_cache.values())
+    guild = FakeGuild(member)
+    member.guild = guild
+    bot.guilds = [guild]
+    bot.get_channel = lambda cid: guild.get_channel(cid)
+
+    send_mock = AsyncMock()
+    monkeypatch.setattr("helpers.username_404.channel_send_message", send_mock)
+    async def immediate(task_func):
+        await task_func()
+    monkeypatch.setattr("helpers.username_404.enqueue_task", lambda fn: immediate(fn))
+
+    # First 404
+    changed1 = await handle_username_404(bot, member, "FirstHandle")
+    assert changed1 is True
+    # Simulate successful re-verification clearing the flag & storing a new handle
+    async with Database.get_connection() as db:
+        await db.execute("UPDATE verification SET rsi_handle=? WHERE user_id=?", ('SecondHandle', 111))
+        await db.commit()
+    await Database.clear_needs_reverify(111)
+    changed2 = await handle_username_404(bot, member, "SecondHandle")
+    assert changed2 is True  # distinct handle should not dedupe
+    # Two spam alerts
+    assert send_mock.await_count == 2
+
+@pytest.mark.asyncio
+async def test_admin_recheck_404_posts_leadership_log(temp_db, monkeypatch):
+    """Admin initiated recheck that hits 404 should emit leadership ChangeSet with 404 note."""
+    async with Database.get_connection() as db:
+        await db.execute("INSERT INTO verification(user_id, rsi_handle, membership_status, last_updated) VALUES (?,?,?,?)", (222, 'GoneHandle', 'main', 1))
+        await db.commit()
+    bot = SimpleNamespace()
+    bot.BOT_SPAM_CHANNEL_ID = 777
+    bot.VERIFICATION_CHANNEL_ID = 555
+    bot.config = {"channels": {"leadership_announcement_channel_id": 999}}
+    bot.role_cache = {}
+    # Channel mocks
+    spam_chan = SimpleNamespace(id=777, send=AsyncMock())
+    leader_chan = SimpleNamespace(id=999, send=AsyncMock())
+    def get_channel(cid):
+        return leader_chan if cid == 999 else (spam_chan if cid == 777 else None)
+    bot.get_channel = get_channel
+    member = FakeMember(uid=222, display_name="UserGone")
+    guild = FakeGuild(member)
+    member.guild = guild
+    bot.guilds = [guild]
+    # Force flag pass through real function; patch enqueue_task immediate
+    async def immediate(task_func):
+        await task_func()
+    monkeypatch.setattr("helpers.username_404.enqueue_task", lambda fn: immediate(fn))
+    # Patch leadership log channel send to be immediate (bypass task queue)
+    async def leader_send_patch(channel, content, embed=None):
+        await leader_chan.send(content)
+    monkeypatch.setattr('helpers.leadership_log.channel_send_message', leader_send_patch)
+    # Patch generic channel send for spam channel path
+    async def spam_send_patch(channel, content, embed=None):
+        await spam_chan.send(content)
+    monkeypatch.setattr('helpers.username_404.channel_send_message', spam_send_patch)
+    # Run 404 handler (simulating admin path already catching NotFound)
+    from helpers.username_404 import handle_username_404
+    await handle_username_404(bot, member, "GoneHandle")
+    # Leadership message posted (header only, no explicit 404 text per current renderer)
+    assert leader_chan.send.await_count == 1
+    leadership_msg = leader_chan.send.await_args_list[0][0][0]
+    assert leadership_msg.startswith('[RECHECK]')
+    # Spam alert also
+    assert spam_chan.send.await_count == 1
+    spam_msg = spam_chan.send.await_args_list[0][0][0]
     assert member.mention in spam_msg
     assert f"<#{bot.VERIFICATION_CHANNEL_ID}>" in spam_msg
     assert "reverify your account" in spam_msg.lower()
-
-    # Second call should be idempotent (no change)
-    changed2 = await handle_username_404(bot, member, "OldHandle")
-    assert changed2 is False
-    # No additional sends
-    assert send_mock.await_count == 1
 
 @pytest.mark.asyncio
 async def test_admin_recheck_404_flow(temp_db, monkeypatch):

--- a/verification/rsi_verification.py
+++ b/verification/rsi_verification.py
@@ -191,8 +191,9 @@ def _sanitize_moniker(moniker: str) -> str:
     """
     if not moniker:
         return ""
-    allowed = set(string.printable) | {" ", "\t"}
-    cleaned = "".join(ch for ch in moniker if ch in allowed and ch != "\x0b" and ch != "\x0c")
+    # Use Python's printable set directly; exclude vertical tab and form feed for safety.
+    allowed = set(string.printable)
+    cleaned = "".join(ch for ch in moniker if ch in allowed and ch not in {"\x0b", "\x0c"})
     # Remove zero-width space explicitly then strip outer whitespace
     return cleaned.replace("\u200b", "").strip()
 

--- a/verification/rsi_verification.py
+++ b/verification/rsi_verification.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import string
 from typing import Optional, Tuple
 from bs4 import BeautifulSoup
 from config.config_loader import ConfigLoader
@@ -179,12 +180,20 @@ def extract_moniker(html_content: str, handle: Optional[str] = None) -> Optional
     return sanitized
 
 
+MIN_PRINTABLE_ASCII = 32
+MAX_PRINTABLE_ASCII = 126
+
 def _sanitize_moniker(moniker: str) -> str:
-    """Remove control/zero-width characters and trim whitespace."""
+    """Remove control / zero-width characters and trim whitespace.
+
+    Accept characters that are in Python's string.printable OR are standard space/tab.
+    Explicitly drop other control characters and zero-width spaces.
+    """
     if not moniker:
         return ""
-    # Remove zero-width & control chars (except common whitespace)
-    cleaned = "".join(ch for ch in moniker if (32 <= ord(ch) <= 126) or ch in " \t")
+    allowed = set(string.printable) | {" ", "\t"}
+    cleaned = "".join(ch for ch in moniker if ch in allowed and ch != "\x0b" and ch != "\x0c")
+    # Remove zero-width space explicitly then strip outer whitespace
     return cleaned.replace("\u200b", "").strip()
 
 

--- a/verification/rsi_verification.py
+++ b/verification/rsi_verification.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 async def is_valid_rsi_handle(
     user_handle: str, http_client: HTTPClient
-) -> Tuple[Optional[int], Optional[str]]:
+) -> Tuple[Optional[int], Optional[str], Optional[str]]:
     """
     Validates the RSI handle by checking if the user is part of the TEST organization or its affiliates.
     Also retrieves the correctly cased handle from the RSI profile.
@@ -26,15 +26,16 @@ async def is_valid_rsi_handle(
         http_client (HTTPClient): The HTTP client instance.
 
     Returns:
-        Tuple[Optional[int], Optional[str]]: A tuple containing:
+        Tuple[Optional[int], Optional[str], Optional[str]]: A tuple containing:
             - verify_value (1, 2, 0 or None)
             - the correctly cased handle (or None)
+            - community moniker (or None)
     """
     logger.debug(f"Starting validation for RSI handle: {user_handle}")
 
     if not RSI_HANDLE_REGEX.match(user_handle):
         logger.warning(f"Invalid RSI handle format: {user_handle}")
-        return None, None
+        return None, None, None
 
         # Fetch organization data
     org_url = f"https://robertsspaceindustries.com/citizens/{user_handle}/organizations"
@@ -47,7 +48,7 @@ async def is_valid_rsi_handle(
         raise
     if not org_html:
         logger.error(f"Failed to fetch organization data for handle: {user_handle}")
-        return None, None
+        return None, None, None
 
         # Parse organization data
     try:
@@ -56,18 +57,18 @@ async def is_valid_rsi_handle(
         logger.exception(
             f"Exception while parsing organization data for {user_handle}: {e}"
         )
-        return None, None
+        return None, None, None
 
     verify_value = search_organization_case_insensitive(org_data, TEST_ORG_NAME)
     logger.debug(f"Verification value for {user_handle}: {verify_value}")
 
-    # Fetch profile data
+    # Fetch profile data (single fetch reused for handle + moniker)
     profile_url = f"https://robertsspaceindustries.com/citizens/{user_handle}"
     logger.debug(f"Fetching profile data from URL: {profile_url}")
     profile_html = await http_client.fetch_html(profile_url)
     if not profile_html:
         logger.error(f"Failed to fetch profile data for handle: {user_handle}")
-        return verify_value, None
+        return verify_value, None, None
 
         # Extract correctly cased handle
     try:
@@ -82,7 +83,24 @@ async def is_valid_rsi_handle(
         )
         cased_handle = None
 
-    return verify_value, cased_handle
+    # Extract community moniker
+    try:
+        community_moniker = extract_moniker(profile_html, cased_handle)
+        if community_moniker:
+            logger.debug(
+                f"Extracted community moniker for {user_handle}: {community_moniker}"
+            )
+        else:
+            logger.info(
+                f"Community moniker not found or empty for {user_handle}; proceeding without it."
+            )
+    except Exception as e:
+        logger.exception(
+            f"Exception while extracting community moniker for {user_handle}: {e}"
+        )
+        community_moniker = None
+
+    return verify_value, cased_handle, community_moniker
 
 
 def extract_handle(html_content: str) -> Optional[str]:
@@ -117,6 +135,68 @@ def extract_handle(html_content: str) -> Optional[str]:
 
     logger.warning("Handle element not found in profile HTML.")
     return None
+
+
+def extract_moniker(html_content: str, handle: Optional[str] = None) -> Optional[str]:
+    """Extract the community moniker (display name) from profile HTML.
+
+    Strategy:
+      1. Parse all p.entry nodes inside the profile info block in DOM order.
+      2. Stop processing once we reach the paragraph whose label/span label text is
+         'Handle name' (that paragraph corresponds to handle section) – do not
+         consider any entries after it.
+      3. Within the processed range, take the first <strong class="value"> text value.
+      4. Fallback: if none found before Handle name, pick the very first
+         <strong class="value"> anywhere (if distinct from handle).
+      5. If extracted moniker equals the handle (case-insensitive) or is empty
+         after stripping, treat as None.
+    """
+    soup = BeautifulSoup(html_content, "lxml")
+    # Primary search region: all profile info entries (broad but ordered)
+    entries = soup.select(".profile .info p.entry") or soup.find_all("p", class_="entry")
+
+    moniker_candidate: Optional[str] = None
+    for p in entries:
+        # If this is the handle section, break before consuming it
+        label_span = p.find("span", class_="label")
+        label_text = label_span.get_text(strip=True) if label_span else ""
+        if label_text == "Handle name":
+            break
+        strong_val = p.find("strong", class_="value")
+        if strong_val:
+            text_val = strong_val.get_text(strip=True)
+            if text_val:
+                moniker_candidate = text_val
+                break  # First pre-handle value wins
+
+    # Fallback if not found pre-handle
+    if not moniker_candidate:
+        strong_any = soup.select_one(".profile .info strong.value") or soup.find(
+            "strong", class_="value"
+        )
+        if strong_any:
+            moniker_candidate = strong_any.get_text(strip=True)
+
+    if not moniker_candidate:
+        return None
+
+    # Normalize / sanitize
+    sanitized = _sanitize_moniker(moniker_candidate)
+    if not sanitized:
+        return None
+    if handle and sanitized.lower() == handle.lower():
+        return None
+    return sanitized
+
+
+def _sanitize_moniker(moniker: str) -> str:
+    """Remove control/zero-width characters and trim whitespace."""
+    if not moniker:
+        return ""
+    # Remove zero-width & control chars (except common whitespace)
+    cleaned = "".join(ch for ch in moniker if (32 <= ord(ch) <= 126) or ch in " \t")
+    cleaned = cleaned.replace("\u200b", "").strip()
+    return cleaned
 
 
 def parse_rsi_organizations(html_content: str) -> dict:


### PR DESCRIPTION
## Summary by Sourcery

Add support for extracting and storing RSI community monikers, sync them into Discord nicknames, and implement a structured leadership logging system for all verification flows while refining config handling and replacing legacy announcement channels.

New Features:
- Extract community moniker from RSI profile and return it alongside handle validation
- Store community moniker in the database and sync it to the user's Discord nickname (truncated with an ellipsis if over 32 characters)
- Introduce a leadership logging system with ChangeSet, snapshot, diff, and post_if_changed to record verification and re-check events

Enhancements:
- Replace channel announcements with unified leadership logs across all verification and re-check commands
- Allow configuring HTTPClient user-agent via config and fall back to a default
- Fallback to mention-only command prefix when configured prefix is empty

Documentation:
- Update verification workflow documentation to describe moniker sync and nickname updates

Tests:
- Add tests for moniker extraction, nickname syncing, leadership logging, and snapshot/diff behavior
- Update existing 404 flow tests to expect only spam channel alerts and leverage new leadership log

Chores:
- Add database migration to include `community_moniker` column
- Introduce `flush_tasks` helper to ensure task queue draining before snapshot logging
- Add new helper modules for leadership logging and member state snapshots