### PR TITLE
Refactor voice settings tests and enhance CI configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           if [ -f requirements-dev.txt ]; then
             pip install -r requirements-dev.txt
           fi
-          pip install pytest pytest-asyncio coverage psutil
+          pip install pytest pytest-asyncio pytest-cov coverage psutil
 
       - name: Copy example config for tests
         run: |
@@ -55,8 +55,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          coverage run -m pytest -q
-          coverage xml
+          pytest -q --cov=. --cov-report=xml
 
       - name: Upload coverage as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           if [ -f requirements-dev.txt ]; then
             pip install -r requirements-dev.txt
           fi
-          pip install pytest pytest-asyncio pytest-cov coverage psutil
+          pip install pytest pytest-asyncio pytest-cov coverage psutil requests
 
       - name: Copy example config for tests
         run: |

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "pytest",
+      "type": "shell",
+      "command": "${workspaceFolder}/.venv/bin/pytest -q",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/cogs/admin/recheck.py
+++ b/cogs/admin/recheck.py
@@ -135,7 +135,7 @@ class AutoRecheck(commands.Cog):
             _start = _t.time()
             before_snap = await snapshot_member_state(self.bot, member)
             # Apply roles; get (old_status, new_status)
-            old_status, new_status = await assign_roles(
+            _old_status, _new_status = await assign_roles(
                 member,
                 verify_value,
                 cased_handle,

--- a/fix_tests.sh
+++ b/fix_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Fix test_voice_cleanup.py to use new schema
+
+# Replace INSERT statements with proper new schema
+sed -i -E 's/INSERT INTO voice_channels[[:space:]]*\(guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at\)[[:space:]]*VALUES \(\?, \?, \?, \?, \?\)/INSERT INTO voice_channels\n                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)\n                VALUES (?, ?, ?, ?, ?, ?, ?)/g' tests/test_voice_cleanup.py
+
+# Update corresponding value tuples - this needs to be done for each specific case
+# We'll need to add two more parameters: last_activity (same as created_at) and is_active (1)

--- a/fix_voice_tests.py
+++ b/fix_voice_tests.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+"""Fix test_voice_cleanup.py to use the new voice_channels schema."""
+
+import re
+
+# Read the test file
+with open('tests/test_voice_cleanup.py') as f:
+    content = f.read()
+
+# Fix INSERT statements - replace the old schema with new one
+old_insert = r'INSERT INTO voice_channels\s*\(guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at\)\s*VALUES \(\?, \?, \?, \?, \?\)'
+new_insert = 'INSERT INTO voice_channels\\n                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)\\n                VALUES (?, ?, ?, ?, ?, ?, ?)'
+
+content = re.sub(old_insert, new_insert, content)
+
+# Fix the corresponding parameter tuples - we need to add two more parameters
+# Find lines with tuples that have 5 parameters for voice_channels inserts
+# Pattern: (12345, 67890, 11111, channel.id, 1234567890), -> (12345, 67890, 11111, channel.id, 1234567890, 1234567890, 1),
+# Also handle cases with numeric values instead of channel.id
+
+patterns_to_fix = [
+    (r'\(12345, 67890, 11111, channel\.id, 1234567890\),', '(12345, 67890, 11111, channel.id, 1234567890, 1234567890, 1),'),
+    (r'\(12345, 67890, (\d+), (\d+), 1234567890\),', r'(12345, 67890, \1, \2, 1234567890, 1234567890, 1),'),
+    (r'\(12345, 67890, (\d+ \+ i), channel_id, 1234567890\),', r'(12345, 67890, \1, channel_id, 1234567890, 1234567890, 1),'),
+]
+
+for pattern, replacement in patterns_to_fix:
+    content = re.sub(pattern, replacement, content)
+
+# Also handle the specific patterns we know exist
+content = re.sub(r'\(12345, 67890, 11111 \+ i, channel_id, 1234567890\),',
+                 '(12345, 67890, 11111 + i, channel_id, 1234567890, 1234567890, 1),', content)
+content = re.sub(r'\(12345, 67890, 22222 \+ i, channel_id, 1234567890\),',
+                 '(12345, 67890, 22222 + i, channel_id, 1234567890, 1234567890, 1),', content)
+content = re.sub(r'\(12345, 67890, 33333 \+ i, channel_id, 1234567890\),',
+                 '(12345, 67890, 33333 + i, channel_id, 1234567890, 1234567890, 1),', content)
+content = re.sub(r'\(12345, 67890, 44444, channel_id, 1234567890\),',
+                 '(12345, 67890, 44444, channel_id, 1234567890, 1234567890, 1),', content)
+
+# Write the fixed content back
+with open('tests/test_voice_cleanup.py', 'w') as f:
+    f.write(content)
+
+print("Fixed test_voice_cleanup.py")

--- a/helpers/modals.py
+++ b/helpers/modals.py
@@ -217,7 +217,7 @@ class HandleModal(Modal, title="Verification"):
         before_snap = await snapshot_member_state(self.bot, member)
 
         # Verification successful
-        old_status, assigned_role_type = await assign_roles(
+        _old_status, assigned_role_type = await assign_roles(
             member,
             verify_value_check,
             cased_handle_used,

--- a/helpers/permissions_helper.py
+++ b/helpers/permissions_helper.py
@@ -173,7 +173,7 @@ async def apply_permissions_changes(
     try:
         async with Database.get_connection() as db:
             cursor = await db.execute(
-                "SELECT owner_id FROM user_voice_channels WHERE voice_channel_id = ?",
+                "SELECT owner_id FROM voice_channels WHERE voice_channel_id = ? AND is_active = 1",
                 (channel.id,),
             )
             row = await cursor.fetchone()
@@ -247,9 +247,9 @@ async def update_channel_owner(
             # Update with guild and JTC channel context
             await db.execute(
                 """
-                UPDATE user_voice_channels
+                UPDATE voice_channels
                 SET owner_id = ?
-                WHERE voice_channel_id = ? AND guild_id = ? AND jtc_channel_id = ?
+                WHERE voice_channel_id = ? AND guild_id = ? AND jtc_channel_id = ? AND is_active = 1
                 """,
                 (new_owner_id, channel.id, guild_id, jtc_channel_id),
             )

--- a/helpers/views.py
+++ b/helpers/views.py
@@ -29,10 +29,10 @@ from helpers.permissions_helper import (
 )
 from helpers.rate_limiter import check_rate_limit, log_attempt
 from helpers.token_manager import generate_token, token_store
+from helpers.voice_settings import fetch_channel_settings
 from helpers.voice_utils import (
     apply_voice_feature_toggle,
     create_voice_settings_embed,
-    fetch_channel_settings,
     format_channel_settings,
     get_user_channel,
     get_user_game_name,
@@ -57,7 +57,7 @@ async def _get_guild_and_jtc_for_user_channel(
     if guild_id is not None:
         async with Database.get_connection() as db:
             cursor = await db.execute(
-                "SELECT jtc_channel_id FROM user_voice_channels WHERE owner_id = ? AND guild_id = ? AND voice_channel_id = ?",
+                "SELECT jtc_channel_id FROM voice_channels WHERE owner_id = ? AND guild_id = ? AND voice_channel_id = ? AND is_active = 1",
                 (user.id, guild_id, channel.id),
             )
             row = await cursor.fetchone()
@@ -410,7 +410,7 @@ class ChannelSettingsView(View):
         # Get the JTC channel ID from the database
         async with Database.get_connection() as db:
             cursor = await db.execute(
-                "SELECT jtc_channel_id FROM user_voice_channels WHERE owner_id = ? AND guild_id = ? AND voice_channel_id = ?",
+                "SELECT jtc_channel_id FROM voice_channels WHERE owner_id = ? AND guild_id = ? AND voice_channel_id = ? AND is_active = 1",
                 (interaction.user.id, guild_id, channel.id),
             )
             row = await cursor.fetchone()

--- a/helpers/voice_repo.py
+++ b/helpers/voice_repo.py
@@ -34,8 +34,9 @@ async def get_user_channel_id(
         cursor = await db.execute(
             """
             SELECT voice_channel_id
-            FROM user_voice_channels
-            WHERE owner_id = ? AND guild_id = ? AND jtc_channel_id = ?
+            FROM voice_channels
+            WHERE owner_id = ? AND guild_id = ? AND jtc_channel_id = ? AND is_active = 1
+            ORDER BY created_at DESC LIMIT 1
             """,
             (owner_id, guild_id, jtc_channel_id),
         )
@@ -61,8 +62,8 @@ async def get_owner_id_by_channel(voice_channel_id: int) -> int | None:
             cursor = await db.execute(
                 """
                 SELECT owner_id
-                FROM user_voice_channels
-                WHERE voice_channel_id = ?
+                FROM voice_channels
+                WHERE voice_channel_id = ? AND is_active = 1
                 """,
                 (voice_channel_id,),
             )
@@ -305,8 +306,8 @@ async def transfer_channel_owner(
             # Get current owner
             cursor = await db.execute(
                 """
-                SELECT owner_id FROM user_voice_channels
-                WHERE voice_channel_id = ? AND guild_id = ? AND jtc_channel_id = ?
+                SELECT owner_id FROM voice_channels
+                WHERE voice_channel_id = ? AND guild_id = ? AND jtc_channel_id = ? AND is_active = 1
                 """,
                 (voice_channel_id, guild_id, jtc_channel_id),
             )
@@ -322,9 +323,9 @@ async def transfer_channel_owner(
             # Transfer channel ownership
             await db.execute(
                 """
-                UPDATE user_voice_channels
+                UPDATE voice_channels
                 SET owner_id = ?
-                WHERE voice_channel_id = ? AND guild_id = ? AND jtc_channel_id = ?
+                WHERE voice_channel_id = ? AND guild_id = ? AND jtc_channel_id = ? AND is_active = 1
                 """,
                 (new_owner_id, voice_channel_id, guild_id, jtc_channel_id),
             )
@@ -490,7 +491,7 @@ async def cleanup_user_voice_data(
         user_id: The Discord user ID
     """
     tables_to_delete = [
-        "user_voice_channels",
+        "voice_channels",
         "channel_settings",
         "channel_permissions",
         "channel_ptt_settings",
@@ -501,8 +502,8 @@ async def cleanup_user_voice_data(
 
     async with Database.get_connection() as db:
         for table in tables_to_delete:
-            # user_voice_channels uses owner_id instead of user_id
-            id_column = "owner_id" if table == "user_voice_channels" else "user_id"
+            # voice_channels uses owner_id instead of user_id
+            id_column = "owner_id" if table == "voice_channels" else "user_id"
 
             await db.execute(
                 f"""
@@ -524,7 +525,7 @@ async def cleanup_legacy_user_voice_data(user_id: int) -> None:
         user_id: The Discord user ID
     """
     tables_to_delete = [
-        ("user_voice_channels", "owner_id"),
+        ("voice_channels", "owner_id"),
         ("channel_settings", "user_id"),
         ("channel_permissions", "user_id"),
         ("channel_ptt_settings", "user_id"),

--- a/helpers/voice_settings.py
+++ b/helpers/voice_settings.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import discord
 
-from helpers.voice_utils import get_user_channel
 from services.db.database import Database
 from utils.logging import get_logger
 
@@ -276,8 +275,8 @@ async def _get_last_used_jtc_channel(guild_id: int, user_id: int) -> int | None:
         async with Database.get_connection() as db:
             cursor = await db.execute(
                 """
-                SELECT last_used_jtc_channel_id 
-                FROM user_jtc_preferences 
+                SELECT last_used_jtc_channel_id
+                FROM user_jtc_preferences
                 WHERE guild_id = ? AND user_id = ?
                 """,
                 (guild_id, user_id),

--- a/helpers/voice_settings.py
+++ b/helpers/voice_settings.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import discord
 
+from helpers.voice_utils import get_user_channel
 from services.db.database import Database
 from utils.logging import get_logger
 
@@ -60,8 +61,8 @@ async def fetch_channel_settings(
             async with Database.get_connection() as db:
                 cursor = await db.execute(
                     """
-                    SELECT jtc_channel_id FROM user_voice_channels
-                    WHERE voice_channel_id = ? AND owner_id = ?
+                    SELECT jtc_channel_id FROM voice_channels
+                    WHERE voice_channel_id = ? AND owner_id = ? AND is_active = 1
                 """,
                     (user.voice.channel.id, user.id),
                 )
@@ -101,23 +102,47 @@ async def fetch_channel_settings(
                             result["settings"] = settings
                             result["jtc_channel_id"] = jtc_channel_id
             else:
-                # For user list: get all saved settings for this user
-                all_settings = await _get_all_user_jtc_settings(guild_id, user.id)
-                if all_settings and not result["settings"]:
-                    # Get the most recent or first available settings
-                    jtc_channel_id = next(iter(all_settings.keys()))
-                    settings = all_settings[jtc_channel_id]
-                    result["settings"] = settings
-                    result["jtc_channel_id"] = jtc_channel_id
-
-                    embed = await _create_settings_embed(
-                        user,
-                        settings,
-                        None,
-                        is_active=False,
-                        jtc_channel_id=jtc_channel_id,
+                # For user list: get saved settings using last used JTC for deterministic behavior
+                last_used_jtc = await _get_last_used_jtc_channel(guild_id, user.id)
+                if last_used_jtc:
+                    # Load settings for last used JTC
+                    settings = await _get_all_user_settings(
+                        guild_id, last_used_jtc, user.id
                     )
-                    result["embeds"].append(embed)
+                    if settings:
+                        result["settings"] = settings
+                        result["jtc_channel_id"] = last_used_jtc
+
+                        embed = await _create_settings_embed(
+                            user,
+                            settings,
+                            None,
+                            is_active=False,
+                            jtc_channel_id=last_used_jtc,
+                        )
+                        result["embeds"].append(embed)
+                else:
+                    # No last used JTC found, get available JTCs for selection
+                    available_jtcs = await _get_available_jtc_channels(guild_id, user.id)
+                    if available_jtcs:
+                        # Create an informative embed prompting user to select a JTC
+                        embed = discord.Embed(
+                            title="🎙️ Multiple JTC Channels Found",
+                            description=f"{user.display_name} has settings in multiple Join-to-Create channels. Please use a specific JTC channel or create/join a channel to set preference.",
+                            color=discord.Color.orange()
+                        )
+
+                        jtc_list = []
+                        for jtc_id in available_jtcs:
+                            jtc_list.append(f"• JTC Channel ID: {jtc_id}")
+
+                        embed.add_field(
+                            name="Available JTC Channels",
+                            value="\n".join(jtc_list),
+                            inline=False
+                        )
+                        result["embeds"].append(embed)
+                    # If no available JTCs, result stays empty (no settings)
 
         return result
 
@@ -243,6 +268,62 @@ async def _get_all_user_jtc_settings(
         logger.exception("Error getting all user JTC settings", exc_info=e)
 
     return all_settings
+
+
+async def _get_last_used_jtc_channel(guild_id: int, user_id: int) -> int | None:
+    """Get the last used JTC channel for a user in a guild."""
+    try:
+        async with Database.get_connection() as db:
+            cursor = await db.execute(
+                """
+                SELECT last_used_jtc_channel_id 
+                FROM user_jtc_preferences 
+                WHERE guild_id = ? AND user_id = ?
+                """,
+                (guild_id, user_id),
+            )
+            row = await cursor.fetchone()
+            return row[0] if row else None
+    except Exception as e:
+        logger.exception("Error getting last used JTC channel", exc_info=e)
+        return None
+
+
+async def _get_available_jtc_channels(guild_id: int, user_id: int) -> list[int]:
+    """Get all JTC channels where a user has settings."""
+    try:
+        async with Database.get_connection() as db:
+            cursor = await db.execute(
+                """
+                SELECT DISTINCT jtc_channel_id
+                FROM channel_settings
+                WHERE guild_id = ? AND user_id = ?
+                ORDER BY jtc_channel_id
+                """,
+                (guild_id, user_id),
+            )
+            rows = await cursor.fetchall()
+            return [row[0] for row in rows]
+    except Exception as e:
+        logger.exception("Error getting available JTC channels", exc_info=e)
+        return []
+
+
+async def update_last_used_jtc_channel(guild_id: int, user_id: int, jtc_channel_id: int) -> None:
+    """Update the last used JTC channel for a user."""
+    try:
+        async with Database.get_connection() as db:
+            await db.execute(
+                """
+                INSERT OR REPLACE INTO user_jtc_preferences
+                (guild_id, user_id, last_used_jtc_channel_id, updated_at)
+                VALUES (?, ?, ?, strftime('%s','now'))
+                """,
+                (guild_id, user_id, jtc_channel_id),
+            )
+            await db.commit()
+    except Exception as e:
+        logger.exception("Error updating last used JTC channel", exc_info=e)
 
 
 async def _create_settings_embed(

--- a/helpers/voice_utils.py
+++ b/helpers/voice_utils.py
@@ -67,7 +67,7 @@ async def get_user_channel(
                         # Remove stale mapping so future checks don't keep trying
                         # to fetch
                         delete_query = (
-                            "DELETE FROM voice_channels WHERE voice_channel_id = ?"
+                            "UPDATE voice_channels SET is_active = 0 WHERE voice_channel_id = ?"
                         )
                         delete_params = (channel_id,)
                         if guild_id and jtc_channel_id:

--- a/helpers/voice_utils.py
+++ b/helpers/voice_utils.py
@@ -4,7 +4,7 @@ import contextlib
 
 import discord
 
-from helpers.discord_api import edit_channel, send_message
+from helpers.discord_api import edit_channel
 from helpers.permissions_helper import FEATURE_CONFIG
 from services.db.database import Database
 from utils.logging import get_logger
@@ -27,25 +27,28 @@ async def get_user_channel(
     """
     async with Database.get_connection() as db:
         if guild_id and jtc_channel_id:
-            # Query for specific guild and JTC channel
+            # Query for specific guild and JTC channel - get the most recent active channel
             cursor = await db.execute(
-                "SELECT voice_channel_id FROM user_voice_channels "
-                "WHERE owner_id = ? AND guild_id = ? AND jtc_channel_id = ?",
+                "SELECT voice_channel_id FROM voice_channels "
+                "WHERE owner_id = ? AND guild_id = ? AND jtc_channel_id = ? AND is_active = 1 "
+                "ORDER BY created_at DESC LIMIT 1",
                 (user.id, guild_id, jtc_channel_id),
             )
         elif guild_id:
-            # Query for specific guild
+            # Query for specific guild - get the most recent active channel
             cursor = await db.execute(
-                "SELECT voice_channel_id FROM user_voice_channels "
-                "WHERE owner_id = ? AND guild_id = ? ORDER BY created_at DESC",
+                "SELECT voice_channel_id FROM voice_channels "
+                "WHERE owner_id = ? AND guild_id = ? AND is_active = 1 "
+                "ORDER BY created_at DESC LIMIT 1",
                 (user.id, guild_id),
             )
         else:
             # Legacy query - all channels, ordered by created_at to ensure
-            # consistent behavior
+            # consistent behavior - get the most recent active channel
             cursor = await db.execute(
-                "SELECT voice_channel_id FROM user_voice_channels "
-                "WHERE owner_id = ? ORDER BY created_at DESC",
+                "SELECT voice_channel_id FROM voice_channels "
+                "WHERE owner_id = ? AND is_active = 1 "
+                "ORDER BY created_at DESC LIMIT 1",
                 (user.id,),
             )
         row = await cursor.fetchone()
@@ -64,7 +67,7 @@ async def get_user_channel(
                         # Remove stale mapping so future checks don't keep trying
                         # to fetch
                         delete_query = (
-                            "DELETE FROM user_voice_channels WHERE voice_channel_id = ?"
+                            "DELETE FROM voice_channels WHERE voice_channel_id = ?"
                         )
                         delete_params = (channel_id,)
                         if guild_id and jtc_channel_id:
@@ -103,10 +106,14 @@ async def update_channel_settings(
 
     Args:
         user_id: The ID of the user
-        guild_id: Optional guild ID to filter by
-        jtc_channel_id: Optional join-to-create channel ID to filter by
+        guild_id: Guild ID (required)
+        jtc_channel_id: Join-to-create channel ID (required)
         **kwargs: Channel settings to update (channel_name, user_limit, lock)
     """
+    if not guild_id or not jtc_channel_id:
+        logger.error("update_channel_settings requires both guild_id and jtc_channel_id")
+        return
+
     fields = []
     values = []
 
@@ -123,30 +130,19 @@ async def update_channel_settings(
     if not fields:
         return
 
-    # Build the query based on provided parameters
-    if guild_id and jtc_channel_id:
-        # Insert with guild and JTC channel IDs
-        insert_query = (
-            "INSERT OR IGNORE INTO channel_settings "
-            "(guild_id, jtc_channel_id, user_id) VALUES (?, ?, ?)"
-        )
-        insert_values = (guild_id, jtc_channel_id, user_id)
+    # Insert with guild and JTC channel IDs
+    insert_query = (
+        "INSERT OR IGNORE INTO channel_settings "
+        "(guild_id, jtc_channel_id, user_id) VALUES (?, ?, ?)"
+    )
+    insert_values = (guild_id, jtc_channel_id, user_id)
 
-        # Update with guild and JTC channel IDs
-        update_query = (
-            f"UPDATE channel_settings SET {', '.join(fields)} "
-            f"WHERE user_id = ? AND guild_id = ? AND jtc_channel_id = ?"
-        )
-        update_values = (*tuple(values), user_id, guild_id, jtc_channel_id)
-    else:
-        # Legacy mode (backward compatibility)
-        insert_query = "INSERT OR IGNORE INTO channel_settings (user_id) VALUES (?)"
-        insert_values = (user_id,)
-
-        update_query = (
-            f"UPDATE channel_settings SET {', '.join(fields)} WHERE user_id = ?"
-        )
-        update_values = (*tuple(values), user_id)
+    # Update with guild and JTC channel IDs
+    update_query = (
+        f"UPDATE channel_settings SET {', '.join(fields)} "
+        f"WHERE user_id = ? AND guild_id = ? AND jtc_channel_id = ?"
+    )
+    update_values = (*tuple(values), user_id, guild_id, jtc_channel_id)
 
     async with Database.get_connection() as db:
         await db.execute(insert_query, insert_values)
@@ -173,9 +169,13 @@ async def set_voice_feature_setting(
         target_id: The target user or role ID to apply the feature to
         target_type: The type of target ("user", "role", or "everyone")
         enable: Whether to enable or disable the feature
-        guild_id: Optional guild ID to filter by
-        jtc_channel_id: Optional join-to-create channel ID to filter by
+        guild_id: Guild ID (required)
+        jtc_channel_id: Join-to-create channel ID (required)
     """
+    if not guild_id or not jtc_channel_id:
+        logger.error("set_voice_feature_setting requires both guild_id and jtc_channel_id")
+        return
+
     cfg = FEATURE_CONFIG.get(feature)
     if not cfg:
         logger.error(f"Unknown feature: {feature}")
@@ -186,27 +186,16 @@ async def set_voice_feature_setting(
 
     t_id = target_id or 0
 
-    if guild_id and jtc_channel_id:
-        query = f"""
-            INSERT OR REPLACE INTO {db_table}
-            (guild_id, jtc_channel_id, user_id, target_id, target_type, {db_column})
-            VALUES (?, ?, ?, ?, ?, ?)
-        """
-        async with Database.get_connection() as db:
-            await db.execute(
-                query, (guild_id, jtc_channel_id, user_id, t_id, target_type, enable)
-            )
-            await db.commit()
-    else:
-        # Legacy mode for backward compatibility
-        query = f"""
-            INSERT OR REPLACE INTO {db_table}
-            (user_id, target_id, target_type, {db_column})
-            VALUES (?, ?, ?, ?)
-        """
-        async with Database.get_connection() as db:
-            await db.execute(query, (user_id, t_id, target_type, enable))
-            await db.commit()
+    query = f"""
+        INSERT OR REPLACE INTO {db_table}
+        (guild_id, jtc_channel_id, user_id, target_id, target_type, {db_column})
+        VALUES (?, ?, ?, ?, ?, ?)
+    """
+    async with Database.get_connection() as db:
+        await db.execute(
+            query, (guild_id, jtc_channel_id, user_id, t_id, target_type, enable)
+        )
+        await db.commit()
 
 
 async def ensure_owner_overwrites(
@@ -222,7 +211,7 @@ async def ensure_owner_overwrites(
     try:
         async with Database.get_connection() as db:
             cursor = await db.execute(
-                "SELECT owner_id FROM user_voice_channels WHERE voice_channel_id = ?",
+                "SELECT owner_id FROM voice_channels WHERE voice_channel_id = ?",
                 (channel.id,),
             )
             row = await cursor.fetchone()
@@ -276,114 +265,7 @@ async def apply_voice_feature_toggle(
         # ------------------------------
 
 
-async def fetch_channel_settings(
-    bot, interaction, allow_inactive=False, guild_id=None, jtc_channel_id=None
-) -> None:
-    """
-    Fetch channel settings and permissions for the user's channel.
-    If allow_inactive=True, we return DB info even if there's no active channel.
 
-    Args:
-        bot: The bot instance
-        interaction: The interaction context
-        allow_inactive: Whether to return settings even if the user doesn't have
-            an active channel
-        guild_id: Optional guild ID to filter by
-        jtc_channel_id: Optional join-to-create channel ID to filter by
-    """
-    channel = await get_user_channel(bot, interaction.user, guild_id, jtc_channel_id)
-
-    if not channel and not allow_inactive:
-        await send_message(interaction, "You don't own a channel.", ephemeral=True)
-        return None
-
-    async with Database.get_connection() as db:
-        if guild_id and jtc_channel_id:
-            cursor = await db.execute(
-                "SELECT channel_name, user_limit, lock FROM channel_settings "
-                "WHERE user_id = ? AND guild_id = ? AND jtc_channel_id = ?",
-                (interaction.user.id, guild_id, jtc_channel_id),
-            )
-        else:
-            cursor = await db.execute(
-                "SELECT channel_name, user_limit, lock FROM channel_settings "
-                "WHERE user_id = ?",
-                (interaction.user.id,),
-            )
-        row = await cursor.fetchone()
-
-    if not row:
-        return None
-
-    channel_name = None
-    user_limit = None
-    lock_state = "Unlocked"
-
-    db_channel_name = row[0]  # None if not set
-    db_user_limit = row[1]  # 0=unlimited
-    db_lock = row[2]  # 0=unlocked, 1=locked
-
-    if channel:
-        channel_name = db_channel_name or channel.name
-        user_limit = db_user_limit or channel.user_limit
-    else:
-        channel_name = db_channel_name or f"{interaction.user.display_name}'s Channel"
-        user_limit = db_user_limit or "No Limit"
-
-    lock_state = "Locked" if db_lock == 1 else "Unlocked"
-
-    # Fetch separate tables for permission, ptt, priority, soundboard
-    perm_rows = await _fetch_settings_table(
-        "channel_permissions", interaction.user.id, guild_id, jtc_channel_id
-    )
-    ptt_rows = await _fetch_settings_table(
-        "channel_ptt_settings", interaction.user.id, guild_id, jtc_channel_id
-    )
-    priority_rows = await _fetch_settings_table(
-        "channel_priority_speaker_settings",
-        interaction.user.id,
-        guild_id,
-        jtc_channel_id,
-    )
-    soundboard_rows = await _fetch_settings_table(
-        "channel_soundboard_settings", interaction.user.id, guild_id, jtc_channel_id
-    )
-
-    return {
-        "channel_name": channel_name,
-        "user_limit": user_limit,
-        "lock_state": lock_state,
-        "perm_rows": perm_rows,
-        "ptt_rows": ptt_rows,
-        "priority_rows": priority_rows,
-        "soundboard_rows": soundboard_rows,
-    }
-
-
-async def _fetch_settings_table(
-    table_name: str, user_id: int, guild_id=None, jtc_channel_id=None
-) -> None:
-    async with Database.get_connection() as db:
-        if guild_id and jtc_channel_id:
-            cursor = await db.execute(
-                f"SELECT target_id, target_type, * FROM {table_name} "
-                f"WHERE user_id = ? AND guild_id = ? AND jtc_channel_id = ?",
-                (user_id, guild_id, jtc_channel_id),
-            )
-        elif guild_id:
-            cursor = await db.execute(
-                f"SELECT target_id, target_type, * FROM {table_name} "
-                f"WHERE user_id = ? AND guild_id = ?",
-                (user_id, guild_id),
-            )
-        else:
-            cursor = await db.execute(
-                f"SELECT target_id, target_type, * FROM {table_name} WHERE user_id = ?",
-                (user_id,),
-            )
-        all_rows = await cursor.fetchall()
-
-    return [(row[0], row[1], row[-1]) for row in all_rows]
 
 
 def create_voice_settings_embed(

--- a/migrations/009_multiple_channels_per_owner.sql
+++ b/migrations/009_multiple_channels_per_owner.sql
@@ -113,6 +113,7 @@ JOIN voice_channels vc ON (
     vs.guild_id = vc.guild_id 
     AND vs.jtc_channel_id = vc.jtc_channel_id 
     AND vs.owner_id = vc.owner_id
+    AND vs.voice_channel_id = vc.voice_channel_id
 )
 WHERE EXISTS (
     SELECT 1 FROM sqlite_master 

--- a/migrations/009_multiple_channels_per_owner.sql
+++ b/migrations/009_multiple_channels_per_owner.sql
@@ -1,0 +1,106 @@
+-- Migration 009: Support Multiple Channels Per Owner Per JTC
+-- Transform the voice_channels table to allow multiple channels per owner per JTC
+
+BEGIN TRANSACTION;
+
+-- First, check if we need to migrate from the old schema
+-- If voice_channels table exists with PRIMARY KEY (guild_id, jtc_channel_id, owner_id),
+-- we need to migrate the data
+
+-- Create new voice_channels table with updated schema
+CREATE TABLE IF NOT EXISTS voice_channels_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    guild_id INTEGER NOT NULL,
+    jtc_channel_id INTEGER NOT NULL,
+    owner_id INTEGER NOT NULL,
+    voice_channel_id INTEGER NOT NULL UNIQUE,
+    created_at INTEGER DEFAULT (strftime('%s','now')),
+    last_activity INTEGER DEFAULT (strftime('%s','now')),
+    is_active INTEGER DEFAULT 1
+);
+
+-- Create indexes for efficient queries
+CREATE INDEX IF NOT EXISTS idx_voice_channels_new_guild_owner_active
+ON voice_channels_new(guild_id, owner_id, is_active);
+
+CREATE INDEX IF NOT EXISTS idx_voice_channels_new_guild_jtc_active
+ON voice_channels_new(guild_id, jtc_channel_id, is_active);
+
+-- Migrate data from old voice_channels table if it exists
+INSERT OR IGNORE INTO voice_channels_new 
+    (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
+SELECT 
+    guild_id, 
+    jtc_channel_id, 
+    owner_id, 
+    voice_channel_id, 
+    created_at, 
+    last_activity, 
+    is_active
+FROM voice_channels 
+WHERE EXISTS (
+    SELECT 1 FROM sqlite_master 
+    WHERE type = 'table' AND name = 'voice_channels'
+);
+
+-- Also migrate from user_voice_channels table if it exists (legacy support)
+INSERT OR IGNORE INTO voice_channels_new 
+    (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, is_active)
+SELECT 
+    guild_id, 
+    jtc_channel_id, 
+    owner_id, 
+    voice_channel_id, 
+    COALESCE(created_at, strftime('%s','now')),
+    1
+FROM user_voice_channels 
+WHERE EXISTS (
+    SELECT 1 FROM sqlite_master 
+    WHERE type = 'table' AND name = 'user_voice_channels'
+)
+AND voice_channel_id NOT IN (SELECT voice_channel_id FROM voice_channels_new);
+
+-- Drop old table and rename new one
+DROP TABLE IF EXISTS voice_channels;
+ALTER TABLE voice_channels_new RENAME TO voice_channels;
+
+-- Create new voice_channel_settings table with updated schema
+CREATE TABLE IF NOT EXISTS voice_channel_settings_new (
+    guild_id INTEGER NOT NULL,
+    jtc_channel_id INTEGER NOT NULL,
+    owner_id INTEGER NOT NULL,
+    voice_channel_id INTEGER NOT NULL,
+    setting_key TEXT NOT NULL,
+    setting_value TEXT,
+    PRIMARY KEY (guild_id, jtc_channel_id, owner_id, voice_channel_id, setting_key),
+    FOREIGN KEY (voice_channel_id)
+    REFERENCES voice_channels(voice_channel_id)
+    ON DELETE CASCADE
+);
+
+-- Migrate settings data if old table exists
+INSERT OR IGNORE INTO voice_channel_settings_new 
+    (guild_id, jtc_channel_id, owner_id, voice_channel_id, setting_key, setting_value)
+SELECT 
+    vs.guild_id, 
+    vs.jtc_channel_id, 
+    vs.owner_id,
+    vc.voice_channel_id,
+    vs.setting_key, 
+    vs.setting_value
+FROM voice_channel_settings vs
+JOIN voice_channels vc ON (
+    vs.guild_id = vc.guild_id 
+    AND vs.jtc_channel_id = vc.jtc_channel_id 
+    AND vs.owner_id = vc.owner_id
+)
+WHERE EXISTS (
+    SELECT 1 FROM sqlite_master 
+    WHERE type = 'table' AND name = 'voice_channel_settings'
+);
+
+-- Drop old settings table and rename new one
+DROP TABLE IF EXISTS voice_channel_settings;
+ALTER TABLE voice_channel_settings_new RENAME TO voice_channel_settings;
+
+COMMIT;

--- a/migrations/009_multiple_channels_per_owner.sql
+++ b/migrations/009_multiple_channels_per_owner.sql
@@ -31,8 +31,9 @@ CREATE TABLE IF NOT EXISTS voice_channels_new (
 );
 
 -- Create indexes for efficient queries
-CREATE INDEX IF NOT EXISTS idx_voice_channels_new_guild_owner_active
-ON voice_channels_new(guild_id, owner_id, is_active);
+-- owner_id first for better selectivity since each user typically has few channels
+CREATE INDEX IF NOT EXISTS idx_voice_channels_new_owner_guild_active
+ON voice_channels_new(owner_id, guild_id, is_active);
 
 CREATE INDEX IF NOT EXISTS idx_voice_channels_new_guild_jtc_active
 ON voice_channels_new(guild_id, jtc_channel_id, is_active);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "PyNaCl==1.5.0",
     "psutil>=5.9.0,<6.0.0",
     "pydantic>=2.0.0,<3.0.0",
+    "requests>=2.28.0,<3.0.0",
     "sqlalchemy[asyncio]>=2.0.0,<3.0.0",
     "typing-extensions>=4.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ addopts = [
     "--cov-report=html",
     "--cov-report=xml",
     "--cov-fail-under=44",
+    "-m", "not integration",
+    "-q",
 ]
 asyncio_mode = "auto"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=html",
     "--cov-report=xml",
+    "--cov-fail-under=44",
 ]
 asyncio_mode = "auto"
 markers = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,6 @@ filterwarnings =
 	ignore:Deprecated call to `pkg_resources.declare_namespace`:DeprecationWarning
 	ignore::DeprecationWarning:discord.*
 	ignore::DeprecationWarning:bs4.*
-addopts = -ra --cov-fail-under=40
+addopts = -ra
 markers =
 	integration: marks tests as integration tests (deselect with '-m "not integration"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@ filterwarnings =
 	ignore:Deprecated call to `pkg_resources.declare_namespace`:DeprecationWarning
 	ignore::DeprecationWarning:discord.*
 	ignore::DeprecationWarning:bs4.*
-addopts = -ra
+addopts = -ra --cov-fail-under=44

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,6 @@ filterwarnings =
 	ignore:Deprecated call to `pkg_resources.declare_namespace`:DeprecationWarning
 	ignore::DeprecationWarning:discord.*
 	ignore::DeprecationWarning:bs4.*
-addopts = -ra --cov-fail-under=44
+addopts = -ra --cov-fail-under=40
+markers =
+	integration: marks tests as integration tests (deselect with '-m "not integration"')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Development dependencies
 pytest>=8.2.0
 pytest-asyncio>=0.23.6
+pytest-cov>=4.0.0
 mypy>=1.8.0
 ruff>=0.3.0
 pre-commit>=3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ lxml>=4.9.3,<5.0.0
 aiosqlite>=0.20.0,<1.0.0
 aiolimiter>=1.1.0,<2.0.0
 PyNaCl==1.5.0
+requests>=2.28.0,<3.0.0
 
 # Development dependencies (install with: pip install -r requirements.txt -r requirements-dev.txt)
 # Or use: pip install -e .[dev] if using pyproject.toml

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -32,11 +32,10 @@ async def migrate_config_to_guild_settings() -> None:
         await Database.initialize()
 
         # Get all guilds from the database (if any exist)
-        async with Database.get_connection() as db:
-            async with db.execute(
-                "SELECT DISTINCT guild_id FROM guild_registry"
-            ) as cursor:
-                guild_ids = [row[0] async for row in cursor]
+        async with Database.get_connection() as db, db.execute(
+            "SELECT DISTINCT guild_id FROM guild_registry"
+        ) as cursor:
+            guild_ids = [row[0] async for row in cursor]
 
         if not guild_ids:
             logger.warning("No guilds found in database. Skipping migration.")

--- a/services/db/database.py
+++ b/services/db/database.py
@@ -119,7 +119,7 @@ class Database:
                 new_cols = []
                 select_cols = []
                 for r in rows:
-                    cid, name, col_type, notnull, dflt_value, pk = r
+                    _cid, name, col_type, notnull, dflt_value, pk = r
                     if name == "last_recheck":
                         continue
                     col_def = f"{name} {col_type or 'TEXT'}"

--- a/services/health_service.py
+++ b/services/health_service.py
@@ -122,19 +122,21 @@ class HealthService(BaseService):
                 # Test basic connectivity
                 await db.execute("SELECT 1")
 
-                # Get table counts
+                # Get table counts - using validated whitelist of table names
                 tables_info = {}
-                table_names = [
+                # Whitelist of known safe table names for security
+                table_names = {
                     "verification",
-                    "guild_settings",
+                    "guild_settings", 
                     "user_voice_channels",
                     "voice_cooldowns",
                     "channel_settings",
                     "guild_registry",
-                ]
+                }
 
                 for table in table_names:
                     try:
+                        # Table name is validated from whitelist above
                         async with db.execute(
                             f"SELECT COUNT(*) FROM {table}"
                         ) as cursor:

--- a/services/voice_service.py
+++ b/services/voice_service.py
@@ -21,6 +21,13 @@ from .base import BaseService
 from .config_service import ConfigService
 
 
+# Function alias for test patching - avoids circular import
+def update_last_used_jtc_channel(guild_id: int, user_id: int, jtc_channel_id: int):
+    """Alias for test patching to avoid circular imports."""
+    from helpers.voice_settings import update_last_used_jtc_channel as real_func
+    return real_func(guild_id, user_id, jtc_channel_id)
+
+
 class VoiceService(BaseService):
     """
     Service for managing voice channels in a race-safe, predictable manner.
@@ -67,7 +74,7 @@ class VoiceService(BaseService):
 
             async with Database.get_connection() as db:
                 cursor = await db.execute(
-                    "SELECT voice_channel_id FROM user_voice_channels"
+                    "SELECT voice_channel_id FROM voice_channels WHERE is_active = 1"
                 )
                 rows = await cursor.fetchall()
 
@@ -171,34 +178,50 @@ class VoiceService(BaseService):
     async def _ensure_voice_tables(self) -> None:
         """Ensure voice-related database tables exist."""
         async with Database.get_connection() as db:
-            # Enhanced voice channels table
+            # Enhanced voice channels table - supports multiple channels per owner per JTC
             await db.execute(
                 """
                 CREATE TABLE IF NOT EXISTS voice_channels (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
                     guild_id INTEGER NOT NULL,
                     jtc_channel_id INTEGER NOT NULL,
                     owner_id INTEGER NOT NULL,
-                    voice_channel_id INTEGER NOT NULL,
+                    voice_channel_id INTEGER NOT NULL UNIQUE,
                     created_at INTEGER DEFAULT (strftime('%s','now')),
                     last_activity INTEGER DEFAULT (strftime('%s','now')),
-                    is_active INTEGER DEFAULT 1,
-                    PRIMARY KEY (guild_id, jtc_channel_id, owner_id)
+                    is_active INTEGER DEFAULT 1
                 )
             """
             )
 
-            # Voice channel settings
+            # Create indexes for efficient queries
+            await db.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_voice_channels_guild_owner_active
+                ON voice_channels(guild_id, owner_id, is_active)
+            """
+            )
+
+            await db.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_voice_channels_guild_jtc_active
+                ON voice_channels(guild_id, jtc_channel_id, is_active)
+            """
+            )
+
+            # Voice channel settings - now references voice channels by voice_channel_id
             await db.execute(
                 """
                 CREATE TABLE IF NOT EXISTS voice_channel_settings (
                     guild_id INTEGER NOT NULL,
                     jtc_channel_id INTEGER NOT NULL,
                     owner_id INTEGER NOT NULL,
+                    voice_channel_id INTEGER NOT NULL,
                     setting_key TEXT NOT NULL,
                     setting_value TEXT,
-                    PRIMARY KEY (guild_id, jtc_channel_id, owner_id, setting_key),
-                    FOREIGN KEY (guild_id, jtc_channel_id, owner_id)
-                    REFERENCES voice_channels(guild_id, jtc_channel_id, owner_id)
+                    PRIMARY KEY (guild_id, jtc_channel_id, owner_id, voice_channel_id, setting_key),
+                    FOREIGN KEY (voice_channel_id)
+                    REFERENCES voice_channels(voice_channel_id)
                     ON DELETE CASCADE
                 )
             """
@@ -252,6 +275,9 @@ class VoiceService(BaseService):
     ) -> tuple[bool, str | None]:
         """
         Check if a user can create a voice channel.
+        
+        For multi-channel support, we only check time-based cooldown,
+        not whether the user already has an existing channel.
 
         Args:
             guild_id: Discord guild ID
@@ -263,12 +289,7 @@ class VoiceService(BaseService):
         """
         self._ensure_initialized()
 
-        # Check if user already has a channel in this JTC
-        existing = await self.get_user_voice_channel(guild_id, jtc_channel_id, user_id)
-        if existing:
-            return False, "You already have a voice channel in this category"
-
-        # Check cooldown
+        # Only check time-based cooldown (removed existing channel check for multi-channel support)
         cooldown_seconds = await self.config_service.get_guild_setting(
             guild_id, "voice.cooldown_seconds", 5
         )
@@ -400,9 +421,7 @@ class VoiceService(BaseService):
                 success = await delete_channel(voice_channel_id, reason)
 
                 # Clean up database records
-                await self._cleanup_voice_channel_records(
-                    guild_id, jtc_channel_id, owner_id
-                )
+                await self.cleanup_by_channel_id(voice_channel_id)
 
                 self.logger.info(f"Deleted voice channel {voice_channel_id}: {reason}")
                 return success
@@ -459,8 +478,10 @@ class VoiceService(BaseService):
             Database.get_connection() as db,
             db.execute(
                 """
-                SELECT voice_channel_id FROM user_voice_channels
-                WHERE guild_id = ? AND jtc_channel_id = ? AND owner_id = ?
+                SELECT voice_channel_id FROM voice_channels
+                WHERE guild_id = ? AND jtc_channel_id = ? AND owner_id = ? AND is_active = 1
+                ORDER BY created_at DESC
+                LIMIT 1
             """,
                 (guild_id, jtc_channel_id, user_id),
             ) as cursor,
@@ -485,9 +506,9 @@ class VoiceService(BaseService):
             Database.get_connection() as db,
             db.execute(
                 """
-                SELECT voice_channel_id FROM user_voice_channels
-                WHERE guild_id = ? AND owner_id = ?
-                ORDER BY voice_channel_id DESC
+                SELECT voice_channel_id FROM voice_channels
+                WHERE guild_id = ? AND owner_id = ? AND is_active = 1
+                ORDER BY created_at DESC
                 LIMIT 1
             """,
                 (guild_id, user_id),
@@ -529,9 +550,7 @@ class VoiceService(BaseService):
             channel = guild.get_channel(voice_channel_id)
             if not channel:
                 # Channel no longer exists, clean up database
-                await self._cleanup_voice_channel_records(
-                    guild.id, jtc_channel_id, owner_id
-                )
+                await self.cleanup_by_channel_id(voice_channel_id)
                 cleaned_count += 1
                 self.logger.debug(
                     f"Cleaned up stale voice channel record: {voice_channel_id}"
@@ -595,28 +614,26 @@ class VoiceService(BaseService):
             )
             await db.commit()
 
-    async def _cleanup_voice_channel_records(
-        self, guild_id: int, jtc_channel_id: int, owner_id: int
-    ) -> None:
-        """Clean up all database records for a voice channel."""
+    async def cleanup_by_channel_id(self, voice_channel_id: int) -> None:
+        """Clean up database records for a specific voice channel."""
         async with Database.get_connection() as db:
             # Mark channel as inactive
             await db.execute(
                 """
                 UPDATE voice_channels
                 SET is_active = 0
-                WHERE guild_id = ? AND jtc_channel_id = ? AND owner_id = ?
+                WHERE voice_channel_id = ?
             """,
-                (guild_id, jtc_channel_id, owner_id),
+                (voice_channel_id,),
             )
 
-            # Clean up settings
+            # Clean up settings for this specific channel
             await db.execute(
                 """
                 DELETE FROM voice_channel_settings
-                WHERE guild_id = ? AND jtc_channel_id = ? AND owner_id = ?
+                WHERE voice_channel_id = ?
             """,
-                (guild_id, jtc_channel_id, owner_id),
+                (voice_channel_id,),
             )
 
             await db.commit()
@@ -879,7 +896,7 @@ class VoiceService(BaseService):
         try:
             async with Database.get_connection() as db:
                 cursor = await db.execute(
-                    "SELECT 1 FROM user_voice_channels WHERE voice_channel_id = ? LIMIT 1",
+                    "SELECT 1 FROM voice_channels WHERE voice_channel_id = ? AND is_active = 1 LIMIT 1",
                     (channel_id,),
                 )
                 return await cursor.fetchone() is not None
@@ -934,13 +951,13 @@ class VoiceService(BaseService):
             try:
                 async with Database.get_connection() as db:
                     await db.execute(
-                        "DELETE FROM user_voice_channels WHERE voice_channel_id = ?",
+                        "UPDATE voice_channels SET is_active = 0 WHERE voice_channel_id = ?",
                         (channel_id,),
                     )
                     await db.commit()
             except Exception as e:
                 self.logger.exception(
-                    "Error removing channel %s from database", channel_id, exc_info=e
+                    "Error updating channel %s in database", channel_id, exc_info=e
                 )
             return
 
@@ -972,14 +989,14 @@ class VoiceService(BaseService):
             try:
                 async with Database.get_connection() as db:
                     await db.execute(
-                        "DELETE FROM user_voice_channels WHERE voice_channel_id = ?",
+                        "UPDATE voice_channels SET is_active = 0 WHERE voice_channel_id = ?",
                         (channel_id,),
                     )
                     await db.commit()
                 self.logger.info(f"Cleaned up tracking for channel {channel_id}")
             except Exception as e:
                 self.logger.exception(
-                    "Error removing channel %s from database", channel_id, exc_info=e
+                    "Error updating channel %s in database", channel_id, exc_info=e
                 )
 
     async def _handle_join_to_create(
@@ -993,23 +1010,6 @@ class VoiceService(BaseService):
             self.logger.info(
                 f"{member.display_name} joined JTC channel {jtc_channel.name}"
             )
-
-            # Check if user already has ANY existing channel in the guild (from any JTC)
-            existing = await self._get_any_user_voice_channel(guild.id, member.id)
-            if existing:
-                # Move them to their existing channel
-                try:
-                    existing_channel = guild.get_channel(existing)
-                    if existing_channel:
-                        await member.move_to(existing_channel)
-                        self.logger.info(
-                            f"Moved {member.display_name} to existing channel"
-                        )
-                        return
-                except Exception as e:
-                    self.logger.warning(
-                        f"Failed to move member to existing channel: {e}"
-                    )
 
             # Check cooldown before creating new channel
             can_create, reason = await self.can_create_voice_channel(
@@ -1040,16 +1040,32 @@ class VoiceService(BaseService):
     ) -> None:
         """Create a new voice channel for a user."""
         try:
+            self.logger.info(
+                f"Creating channel for {member.display_name} (ID: {member.id}) in guild {guild.id}, JTC channel {jtc_channel.id} ('{jtc_channel.name}')"
+            )
+
             # Load saved settings from database
             saved_settings = await self._load_channel_settings(
                 guild.id, jtc_channel.id, member.id
             )
 
+            # Debug logging to see what settings are loaded
+            if saved_settings:
+                self.logger.info(
+                    f"✅ Loaded settings for {member.display_name} (ID: {member.id}) in JTC {jtc_channel.id}: {saved_settings}"
+                )
+            else:
+                self.logger.info(
+                    f"❌ No saved settings found for {member.display_name} (ID: {member.id}) in JTC {jtc_channel.id}"
+                )
+
             # Generate channel name - use saved name if available, otherwise default
             if saved_settings and saved_settings.get("channel_name"):
                 channel_name = saved_settings["channel_name"]
+                self.logger.info(f"✅ Using saved channel name: '{channel_name}'")
             else:
                 channel_name = f"{member.display_name}'s Channel"
+                self.logger.info(f"➡️  Using default channel name: '{channel_name}'")
 
             # Create the channel in the same category as the JTC channel
             category = jtc_channel.category
@@ -1120,6 +1136,9 @@ class VoiceService(BaseService):
             # Update cooldown
             await self._update_cooldown(guild.id, jtc_channel.id, member.id)
 
+            # Update last used JTC channel for deterministic settings behavior
+            await update_last_used_jtc_channel(guild.id, member.id, jtc_channel.id)
+
             # Add to managed channels set
             self.managed_voice_channels.add(channel.id)
 
@@ -1183,13 +1202,14 @@ class VoiceService(BaseService):
         """Store user channel in database."""
         try:
             async with Database.get_connection() as db:
+                # Use the new voice_channels table with multiple channels support
                 await db.execute(
                     """
-                    INSERT OR REPLACE INTO user_voice_channels
-                    (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
-                    VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO voice_channels
+                    (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                    (guild_id, jtc_channel_id, user_id, channel_id, int(time.time())),
+                    (guild_id, jtc_channel_id, user_id, channel_id, int(time.time()), int(time.time()), 1),
                 )
                 await db.commit()
 
@@ -1367,7 +1387,7 @@ class VoiceService(BaseService):
 
 
         For each guild the bot is in:
-        - Fetch all rows from user_voice_channels
+        - Fetch all rows from voice_channels
         - Check if channels still exist
         - If not exists → remove DB row
         - If exists and has members or owner connected → keep and rehydrate management
@@ -1389,7 +1409,7 @@ class VoiceService(BaseService):
                 # Fetch all user voice channels across all guilds
                 cursor = await db.execute(
                     """SELECT guild_id, voice_channel_id, owner_id, jtc_channel_id, created_at
-                       FROM user_voice_channels"""
+                       FROM voice_channels WHERE is_active = 1"""
                 )
                 all_channels = await cursor.fetchall()
 
@@ -1469,7 +1489,7 @@ class VoiceService(BaseService):
             self.logger.info(f"Removing stale channel {voice_channel_id} from database")
             async with Database.get_connection() as db:
                 await db.execute(
-                    "DELETE FROM user_voice_channels WHERE voice_channel_id = ?",
+                    "UPDATE voice_channels SET is_active = 0 WHERE voice_channel_id = ?",
                     (voice_channel_id,),
                 )
                 await db.commit()
@@ -1662,6 +1682,9 @@ class VoiceService(BaseService):
             Dictionary of settings or None if no settings exist
         """
         try:
+            self.logger.debug(
+                f"Loading channel settings for user {user_id} in guild {guild_id}, JTC {jtc_channel_id}"
+            )
             async with Database.get_connection() as db:
                 cursor = await db.execute(
                     """
@@ -1674,14 +1697,19 @@ class VoiceService(BaseService):
                 row = await cursor.fetchone()
 
                 if not row:
+                    self.logger.debug(
+                        f"No settings row found for user {user_id}, guild {guild_id}, JTC {jtc_channel_id}"
+                    )
                     return None
 
                 channel_name, user_limit, lock = row
-                return {
+                result = {
                     "channel_name": channel_name,
                     "user_limit": user_limit,
                     "lock": lock,
                 }
+                self.logger.debug(f"Found settings: {result}")
+                return result
 
         except Exception as e:
             self.logger.exception("Error loading channel settings", exc_info=e)
@@ -1781,12 +1809,12 @@ class VoiceService(BaseService):
 
             channel = user.voice.channel
 
-            # Check if this is a managed voice channel from user_voice_channels
+            # Check if this is a managed voice channel from voice_channels
             async with Database.get_connection() as db:
                 cursor = await db.execute(
                     """
-                    SELECT owner_id, jtc_channel_id FROM user_voice_channels
-                    WHERE guild_id = ? AND voice_channel_id = ?
+                    SELECT owner_id, jtc_channel_id FROM voice_channels
+                    WHERE guild_id = ? AND voice_channel_id = ? AND is_active = 1
                 """,
                     (guild_id, channel.id),
                 )
@@ -1865,11 +1893,12 @@ class VoiceService(BaseService):
         """
         try:
             async with Database.get_connection() as db:
-                # Find the user's voice channel from user_voice_channels table
+                # Find the user's voice channel from voice_channels table
                 cursor = await db.execute(
                     """
-                    SELECT voice_channel_id, jtc_channel_id FROM user_voice_channels
-                    WHERE guild_id = ? AND owner_id = ?
+                    SELECT voice_channel_id, jtc_channel_id FROM voice_channels
+                    WHERE guild_id = ? AND owner_id = ? AND is_active = 1
+                    ORDER BY created_at DESC LIMIT 1
                 """,
                     (guild_id, current_owner_id),
                 )
@@ -1935,7 +1964,7 @@ class VoiceService(BaseService):
 
     async def get_all_voice_channels(self, guild_id: int) -> list[dict[str, Any]]:
         """
-        Get all managed voice channels for a guild from user_voice_channels table.
+        Get all managed voice channels for a guild from voice_channels table.
 
         Args:
             guild_id: Discord guild ID
@@ -1948,8 +1977,8 @@ class VoiceService(BaseService):
                 cursor = await db.execute(
                     """
                     SELECT owner_id, voice_channel_id, created_at
-                    FROM user_voice_channels
-                    WHERE guild_id = ?
+                    FROM voice_channels
+                    WHERE guild_id = ? AND is_active = 1
                     ORDER BY created_at DESC
                 """,
                     (guild_id,),
@@ -2181,7 +2210,7 @@ class VoiceService(BaseService):
         try:
             async with Database.get_connection() as db:
                 cursor = await db.execute(
-                    "SELECT voice_channel_id FROM user_voice_channels WHERE guild_id = ?",
+                    "SELECT voice_channel_id FROM voice_channels WHERE guild_id = ? AND is_active = 1",
                     (guild_id,),
                 )
                 rows = await cursor.fetchall()
@@ -2261,8 +2290,8 @@ class VoiceService(BaseService):
                 cursor = await db.execute(
                     f"""
                     SELECT voice_channel_id, jtc_channel_id
-                    FROM user_voice_channels
-                    WHERE guild_id = ? AND jtc_channel_id IN ({placeholders})
+                    FROM voice_channels
+                    WHERE guild_id = ? AND jtc_channel_id IN ({placeholders}) AND is_active = 1
                     """,
                     [guild_id, *stale_jtc_list],
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,10 +120,10 @@ def mock_db_connection():
     """
     Patches Database.get_connection() to yield an async mock connection
     with helpers to set cursor.fetchone.return_value.
-    
+
     Patches both the direct import path and the services.voice_service path
     to ensure compatibility with all test patterns.
-    
+
     Returns a helper object with methods to configure the mock database responses.
     """
 
@@ -149,9 +149,8 @@ def mock_db_connection():
             """Assert a specific query was called with parameters."""
             calls = self.get_connection_calls()
             for call in calls:
-                if call[0][0] == query:
-                    if params is None or call[0][1] == params:
-                        return True
+                if call[0][0] == query and (params is None or call[0][1] == params):
+                    return True
             raise AssertionError(f"Query not found: {query} with params {params}")
 
     helper = MockDBHelper()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -13,7 +14,9 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from services.config_service import ConfigService  # noqa: E402
 from services.db.database import Database  # noqa: E402
+from services.voice_service import VoiceService  # noqa: E402
 
 
 # Ensure pytest-asyncio uses a dedicated loop
@@ -110,3 +113,63 @@ class FakeInteraction:
             return None
 
         self.message = SimpleNamespace(edit=_edit)
+
+
+@pytest.fixture
+def mock_db_connection():
+    """
+    Patches Database.get_connection() to yield an async mock connection
+    with helpers to set cursor.fetchone.return_value.
+    
+    Patches both the direct import path and the services.voice_service path
+    to ensure compatibility with all test patterns.
+    
+    Returns a helper object with methods to configure the mock database responses.
+    """
+
+    class MockDBHelper:
+        def __init__(self):
+            self.mock_conn = AsyncMock()
+            self.mock_cursor = AsyncMock()
+            self.mock_conn.execute.return_value = self.mock_cursor
+
+        def set_fetchone_result(self, result):
+            """Set the result that cursor.fetchone() will return."""
+            self.mock_cursor.fetchone.return_value = result
+
+        def set_fetchall_result(self, result):
+            """Set the result that cursor.fetchall() will return."""
+            self.mock_cursor.fetchall.return_value = result
+
+        def get_connection_calls(self):
+            """Get all calls made to connection.execute()."""
+            return self.mock_conn.execute.call_args_list
+
+        def assert_query_called_with(self, query, params=None):
+            """Assert a specific query was called with parameters."""
+            calls = self.get_connection_calls()
+            for call in calls:
+                if call[0][0] == query:
+                    if params is None or call[0][1] == params:
+                        return True
+            raise AssertionError(f"Query not found: {query} with params {params}")
+
+    helper = MockDBHelper()
+
+    # Patch both possible import paths to ensure compatibility
+    with patch("services.voice_service.Database.get_connection") as mock_db1, \
+         patch("services.db.database.Database.get_connection") as mock_db2:
+
+        mock_db1.return_value.__aenter__.return_value = helper.mock_conn
+        mock_db2.return_value.__aenter__.return_value = helper.mock_conn
+        yield helper
+
+
+@pytest.fixture
+def voice_service(mock_bot):
+    """Create a VoiceService instance for testing."""
+    config_service = MagicMock(spec=ConfigService)
+    service = VoiceService(config_service, mock_bot)
+    # Skip actual initialization to avoid database/network calls
+    service._initialized = True
+    return service

--- a/tests/test_admin_config_choices.py
+++ b/tests/test_admin_config_choices.py
@@ -57,7 +57,7 @@ class TestConfigSchema:
         assert "must be at least 0" in error
 
         # Test above maximum
-        is_valid, error, coerced = ConfigSchema.validate_value(
+        is_valid, error, _coerced = ConfigSchema.validate_value(
             "voice.cooldown_seconds", "5000"
         )
         assert is_valid is False
@@ -65,7 +65,7 @@ class TestConfigSchema:
 
     def test_validate_value_int_type_error(self):
         """Test integer validation with invalid type."""
-        is_valid, error, coerced = ConfigSchema.validate_value(
+        is_valid, error, _coerced = ConfigSchema.validate_value(
             "voice.cooldown_seconds", "not_a_number"
         )
 
@@ -96,7 +96,7 @@ class TestConfigSchema:
 
     def test_validate_value_bool_error(self):
         """Test boolean validation with invalid values."""
-        is_valid, error, coerced = ConfigSchema.validate_value(
+        is_valid, error, _coerced = ConfigSchema.validate_value(
             "features.auto_role", "maybe"
         )
 
@@ -114,7 +114,7 @@ class TestConfigSchema:
 
     def test_validate_value_unknown_key(self):
         """Test validation with unknown configuration key."""
-        is_valid, error, coerced = ConfigSchema.validate_value("unknown.key", "value")
+        is_valid, error, _coerced = ConfigSchema.validate_value("unknown.key", "value")
 
         assert is_valid is False
         assert "Unknown configuration key" in error
@@ -133,7 +133,7 @@ class TestConfigSchema:
 
     def test_validate_value_list_int_invalid_json(self):
         """Test list<int> validation with invalid JSON."""
-        is_valid, error, coerced = ConfigSchema.validate_value(
+        is_valid, error, _coerced = ConfigSchema.validate_value(
             "roles.bot_admins", "[123, invalid"
         )
 
@@ -142,7 +142,7 @@ class TestConfigSchema:
 
     def test_validate_value_list_int_invalid_element(self):
         """Test list<int> validation with invalid element type."""
-        is_valid, error, coerced = ConfigSchema.validate_value(
+        is_valid, error, _coerced = ConfigSchema.validate_value(
             "roles.bot_admins", '[123, "text"]'
         )
 

--- a/tests/test_is_valid_rsi_handle_moniker.py
+++ b/tests/test_is_valid_rsi_handle_moniker.py
@@ -92,7 +92,7 @@ async def test_is_valid_rsi_handle_malformed_profile(monkeypatch) -> None:
             "https://robertsspaceindustries.com/citizens/TestUser": MALFORMED_PROFILE,
         }
     )
-    verify_value, cased_handle, moniker = await rv.is_valid_rsi_handle("TestUser", http)
+    verify_value, _cased_handle, moniker = await rv.is_valid_rsi_handle("TestUser", http)
     # Handle should still be found (CaseHandle) absence due to malformed
     # structure may null it
     assert verify_value == 1

--- a/tests/test_ownership_transfer_final.py
+++ b/tests/test_ownership_transfer_final.py
@@ -105,8 +105,8 @@ class TestOwnershipTransferSanity:
         # Insert initial data
         async with Database.get_connection() as db:
             await db.execute(
-                """INSERT INTO user_voice_channels (guild_id, jtc_channel_id, owner_id, voice_channel_id)
-                   VALUES (?, ?, ?, ?)""",
+                """INSERT INTO voice_channels (guild_id, jtc_channel_id, owner_id, voice_channel_id, is_active)
+                   VALUES (?, ?, ?, ?, 1)""",
                 (guild_id, jtc_channel_id, old_owner_id, voice_channel_id),
             )
 
@@ -127,15 +127,15 @@ class TestOwnershipTransferSanity:
 
         # Verify database changes
         async with Database.get_connection() as db:
-            # Verify user_voice_channels updated (authoritative table)
+            # Verify voice_channels updated (authoritative table)
             cursor = await db.execute(
-                "SELECT owner_id FROM user_voice_channels WHERE voice_channel_id = ?",
+                "SELECT owner_id FROM voice_channels WHERE voice_channel_id = ?",
                 (voice_channel_id,),
             )
             row = await cursor.fetchone()
             assert (
                 row[0] == new_owner_id
-            ), "user_voice_channels.owner_id should be updated"
+            ), "voice_channels.owner_id should be updated"
 
             # Verify settings transferred
             cursor = await db.execute(

--- a/tests/test_rsi_live_probe.py
+++ b/tests/test_rsi_live_probe.py
@@ -38,10 +38,7 @@ def rsi_session(test_config):
     return session
 
 
-@pytest.mark.skipif(
-    os.getenv('RSI_LIVE') != '1',
-    reason="RSI live tests require RSI_LIVE=1 environment variable"
-)
+@pytest.mark.integration
 class TestRSILiveProbe:
     """Live tests for RSI probe functionality."""
 
@@ -54,6 +51,9 @@ class TestRSILiveProbe:
 
     def test_session_creation(self, test_config):
         """Test that we can create a session with proper headers."""
+        if os.getenv('RSI_LIVE') != '1':
+            pytest.skip("RSI live tests require RSI_LIVE=1 environment variable")
+
         session = create_session(test_config['user_agent'])
         assert session is not None
         assert 'User-Agent' in session.headers
@@ -63,6 +63,9 @@ class TestRSILiveProbe:
 
     def test_warmup_functionality(self, rsi_session):
         """Test that warmup request works."""
+        if os.getenv('RSI_LIVE') != '1':
+            pytest.skip("RSI live tests require RSI_LIVE=1 environment variable")
+
         # Test warmup function directly
         result = warmup(rsi_session)
         # Warmup may or may not succeed, just verify it doesn't crash
@@ -71,6 +74,9 @@ class TestRSILiveProbe:
     @pytest.mark.parametrize('handle', TEST_HANDLES)
     def test_probe_handle(self, rsi_session, test_config, handle):
         """Test probing individual handles."""
+        if os.getenv('RSI_LIVE') != '1':
+            pytest.skip("RSI live tests require RSI_LIVE=1 environment variable")
+
         # Use temporary directory for save_bodies if specified
         save_bodies_dir = None
         if test_config['save_bodies']:
@@ -154,6 +160,9 @@ class TestRSILiveProbe:
 
     def test_probe_all_handles(self, rsi_session, test_config):
         """Test probing all handles together and provide summary."""
+        if os.getenv('RSI_LIVE') != '1':
+            pytest.skip("RSI live tests require RSI_LIVE=1 environment variable")
+
         # Use temporary directory for save_bodies if specified
         save_bodies_dir = None
         if test_config['save_bodies']:
@@ -216,16 +225,3 @@ class TestRSILiveProbe:
             assert 'endpoints' in result
             assert 'summary' in result
             assert len(result['endpoints']) >= 2  # At least citizen and org
-
-
-# Allow running this test file directly for debugging
-if __name__ == '__main__':
-    if os.getenv('RSI_LIVE') != '1':
-        print("Set RSI_LIVE=1 to run live RSI tests")
-        print("Optional environment variables:")
-        print("  RSI_UA='Mozilla/5.0 TESTBot'")
-        print("  RSI_TRY_EN=1")
-        print("  RSI_SAVE_BODIES=/path/to/save/dir")
-        sys.exit(1)
-
-    pytest.main([__file__, '-v'])

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -235,7 +235,7 @@ class TestVoiceService:
         user_id = 111
 
         # Test creation when allowed
-        can_create, reason = await voice_service.can_create_voice_channel(
+        can_create, _reason = await voice_service.can_create_voice_channel(
             guild_id, jtc_channel_id, user_id
         )
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -13,5 +13,4 @@ def test_smoke_import():
 
     # Import a config module
 
-    # Test passes if all imports succeed
-    assert True
+    # Test passes if all imports succeed without exceptions

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -8,9 +8,14 @@ def test_smoke_import():
     and that the basic package structure can be imported without errors.
     """
     # Import a core service module to verify the package structure
+    # Import a config module
+    from config.config_loader import ConfigLoader
 
     # Import a helper module - check that the module imports successfully
-
-    # Import a config module
+    from services.config_service import ConfigService
+    from services.voice_service import VoiceService
 
     # Test passes if all imports succeed without exceptions
+    assert VoiceService is not None
+    assert ConfigService is not None
+    assert ConfigLoader is not None

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,17 @@
+"""
+Smoke test to verify pytest wiring and basic imports work.
+"""
+
+def test_smoke_import():
+    """
+    Basic smoke test that imports a core module to verify pytest wiring
+    and that the basic package structure can be imported without errors.
+    """
+    # Import a core service module to verify the package structure
+
+    # Import a helper module - check that the module imports successfully
+
+    # Import a config module
+
+    # Test passes if all imports succeed
+    assert True

--- a/tests/test_username_404_flow.py
+++ b/tests/test_username_404_flow.py
@@ -281,7 +281,7 @@ async def test_admin_recheck_404_flow(temp_db, monkeypatch) -> None:
 
     # Call reverify_member and expect it to return failure result (not raise)
     result = await reverify_member(member, "HandleX", bot)
-    success, status_info, message = result
+    success, status_info, _message = result
 
     # Should return failure due to NotFoundError
     assert not success, "reverify_member should return False for NotFoundError"

--- a/tests/test_voice_cleanup.py
+++ b/tests/test_voice_cleanup.py
@@ -198,6 +198,9 @@ class TestVoiceCleanup:
         for channel_id in missing_channel_ids:
             assert channel_id not in voice_service.managed_voice_channels
 
+        # Run reconciliation to properly handle missing channels
+        await voice_service.reconcile_all_guilds_on_ready()
+
         # _load_managed_channels should NOT delete DB rows - it defers to reconciliation
         # Verify database rows are still there (this is correct behavior)
         async with Database.get_connection() as db:
@@ -209,6 +212,14 @@ class TestVoiceCleanup:
             assert (
                 count[0] == 3
             )  # Should still be 3 since _load_managed_channels defers to reconciliation
+
+            # Assert that is_active is 0 for missing channels after reconciliation
+            cursor = await db.execute(
+                "SELECT is_active FROM voice_channels WHERE voice_channel_id IN (?, ?, ?)",
+                missing_channel_ids,
+            )
+            is_active_values = await cursor.fetchall()
+            assert all(row[0] == 0 for row in is_active_values), "is_active should be 0 for missing channels after reconciliation"
 
     @pytest.mark.asyncio
     async def test_startup_reconciliation_active_channels(self, voice_service_with_bot):

--- a/tests/test_voice_cleanup.py
+++ b/tests/test_voice_cleanup.py
@@ -173,7 +173,7 @@ class TestVoiceCleanup:
         self, voice_service_with_bot
     ):
         """Test startup reconciliation removes missing channels from database."""
-        voice_service, mock_bot = voice_service_with_bot
+        voice_service, _mock_bot = voice_service_with_bot
 
         # Add non-existent channels to database
         missing_channel_ids = [99997, 99998, 99999]
@@ -419,14 +419,13 @@ class TestVoiceCleanup:
         # Set very short cleanup delay for testing
         with patch.object(
             voice_service.config_service, "get_global_setting", return_value=0.1
-        ):
-            with patch.object(channel, "delete", new_callable=AsyncMock) as mock_delete:
-                # Schedule cleanup and wait
-                await voice_service._schedule_channel_cleanup(channel.id)
-                await asyncio.sleep(0.2)  # Wait for cleanup to complete
+        ), patch.object(channel, "delete", new_callable=AsyncMock) as mock_delete:
+            # Schedule cleanup and wait
+            await voice_service._schedule_channel_cleanup(channel.id)
+            await asyncio.sleep(0.2)  # Wait for cleanup to complete
 
-                # Verify channel was deleted
-                mock_delete.assert_called_once()
+            # Verify channel was deleted
+            mock_delete.assert_called_once()
 
         # Verify cleanup
         assert channel.id not in voice_service.managed_voice_channels
@@ -453,19 +452,18 @@ class TestVoiceCleanup:
         # Set very short cleanup delay for testing
         with patch.object(
             voice_service.config_service, "get_global_setting", return_value=0.1
-        ):
-            with patch.object(channel, "delete", new_callable=AsyncMock) as mock_delete:
-                # Schedule cleanup
-                await voice_service._schedule_channel_cleanup(channel.id)
+        ), patch.object(channel, "delete", new_callable=AsyncMock) as mock_delete:
+            # Schedule cleanup
+            await voice_service._schedule_channel_cleanup(channel.id)
 
-                # Add a member before cleanup occurs
-                mock_member = MagicMock()
-                channel.members.append(mock_member)
+            # Add a member before cleanup occurs
+            mock_member = MagicMock()
+            channel.members.append(mock_member)
 
-                await asyncio.sleep(0.2)  # Wait for cleanup attempt
+            await asyncio.sleep(0.2)  # Wait for cleanup attempt
 
-                # Verify channel was NOT deleted
-                mock_delete.assert_not_called()
+            # Verify channel was NOT deleted
+            mock_delete.assert_not_called()
 
         # Channel should still be managed
         assert channel.id in voice_service.managed_voice_channels
@@ -565,7 +563,7 @@ class TestVoiceCleanup:
     @pytest.mark.asyncio
     async def test_cleanup_with_channel_id_none_channel(self, voice_service_with_bot):
         """Test cleanup with channel ID when bot.get_channel returns None."""
-        voice_service, mock_bot = voice_service_with_bot
+        voice_service, _mock_bot = voice_service_with_bot
 
         # Add channel to managed channels and database without adding to bot
         channel_id = 12349

--- a/tests/test_voice_cleanup.py.backup
+++ b/tests/test_voice_cleanup.py.backup
@@ -89,10 +89,10 @@ class TestVoiceCleanup:
             await db.execute(
                 """
                 INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                VALUES (?, ?, ?, ?, ?)
             """,
-                (12345, 67890, 11111, channel.id, 1234567890, 1234567890, 1),
+                (12345, 67890, 11111, channel.id, 1234567890),
             )
             await db.commit()
 
@@ -139,10 +139,10 @@ class TestVoiceCleanup:
             await db.execute(
                 """
                 INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                VALUES (?, ?, ?, ?, ?)
             """,
-                (12345, 67890, 11111, channel.id, 1234567890, 1234567890, 1),
+                (12345, 67890, 11111, channel.id, 1234567890),
             )
             await db.commit()
 
@@ -183,10 +183,10 @@ class TestVoiceCleanup:
                 await db.execute(
                     """
                     INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                    (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                    VALUES (?, ?, ?, ?, ?)
                 """,
-                    (12345, 67890, 11111 + i, channel_id, 1234567890, 1234567890, 1),
+                    (12345, 67890, 11111 + i, channel_id, 1234567890),
                 )
             await db.commit()
 
@@ -229,10 +229,10 @@ class TestVoiceCleanup:
                 await db.execute(
                     """
                     INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                    (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                    VALUES (?, ?, ?, ?, ?)
                 """,
-                    (12345, 67890, 11111 + i, channel_id, 1234567890, 1234567890, 1),
+                    (12345, 67890, 11111 + i, channel_id, 1234567890),
                 )
                 await db.commit()
 
@@ -273,10 +273,10 @@ class TestVoiceCleanup:
                 await db.execute(
                     """
                     INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                    (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                    VALUES (?, ?, ?, ?, ?)
                 """,
-                    (12345, 67890, 22222 + i, channel_id, 1234567890, 1234567890, 1),
+                    (12345, 67890, 22222 + i, channel_id, 1234567890),
                 )
                 await db.commit()
 
@@ -316,10 +316,10 @@ class TestVoiceCleanup:
                 await db.execute(
                     """
                     INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                    (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                    VALUES (?, ?, ?, ?, ?)
                 """,
-                    (12345, 67890, 33333 + i, channel_id, 1234567890, 1234567890, 1),
+                    (12345, 67890, 33333 + i, channel_id, 1234567890),
                 )
                 await db.commit()
 
@@ -373,10 +373,10 @@ class TestVoiceCleanup:
             await db.execute(
                 """
                 INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                VALUES (?, ?, ?, ?, ?)
             """,
-                (12345, 67890, 44444, channel_id, 1234567890, 1234567890, 1),
+                (12345, 67890, 44444, channel_id, 1234567890),
             )
             await db.commit()
 
@@ -409,10 +409,10 @@ class TestVoiceCleanup:
             await db.execute(
                 """
                 INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                VALUES (?, ?, ?, ?, ?)
             """,
-                (12345, 67890, 11111, channel.id, 1234567890, 1234567890, 1),
+                (12345, 67890, 11111, channel.id, 1234567890),
             )
             await db.commit()
 
@@ -485,10 +485,10 @@ class TestVoiceCleanup:
             await db.execute(
                 """
                 INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                VALUES (?, ?, ?, ?, ?)
             """,
-                (12345, 67890, 11111, channel.id, 1234567890, 1234567890, 1),
+                (12345, 67890, 11111, channel.id, 1234567890),
             )
             await db.commit()
 
@@ -530,10 +530,10 @@ class TestVoiceCleanup:
             await db.execute(
                 """
                 INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                VALUES (?, ?, ?, ?, ?)
             """,
-                (12345, 67890, 11111, channel.id, 1234567890, 1234567890, 1),
+                (12345, 67890, 11111, channel.id, 1234567890),
             )
             await db.commit()
 
@@ -574,10 +574,10 @@ class TestVoiceCleanup:
             await db.execute(
                 """
                 INSERT INTO voice_channels
-                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at)
+                VALUES (?, ?, ?, ?, ?)
             """,
-                (12345, 67890, 11111, channel_id, 1234567890, 1234567890, 1),
+                (12345, 67890, 11111, channel_id, 1234567890),
             )
             await db.commit()
 

--- a/tests/test_voice_multiple_channels.py
+++ b/tests/test_voice_multiple_channels.py
@@ -1,0 +1,307 @@
+"""
+Test for multiple channels per owner per JTC functionality.
+
+Verifies that joining a JTC channel always creates a new channel,
+even when the user already has an active channel from the same JTC.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+from services.config_service import ConfigService
+from services.db.database import Database
+from services.voice_service import VoiceService
+
+
+class MockVoiceChannel:
+    """Mock Discord voice channel."""
+
+    def __init__(
+        self, channel_id: int, name: str = "test-channel", members: list | None = None, category=None
+    ):
+        self.id = channel_id
+        self.name = name
+        self.members = members or []
+        self.category = category or MagicMock()
+        self.guild = MagicMock()
+        self.guild.id = 12345
+        self.user_limit = 0
+        self.bitrate = 64000
+
+    async def delete(self, reason: str | None = None):
+        """Mock channel deletion."""
+        pass
+
+
+class MockMember:
+    """Mock Discord member."""
+
+    def __init__(self, user_id: int, display_name: str = "TestUser"):
+        self.id = user_id
+        self.display_name = display_name
+        self.voice = MagicMock()
+        self.voice.channel = None
+        self.top_role = MagicMock()
+        self.top_role.name = "member"
+
+    async def move_to(self, channel):
+        """Mock member move."""
+        pass
+
+    async def send(self, message: str):
+        """Mock sending DM to member."""
+        pass
+
+
+class MockGuild:
+    """Mock Discord guild."""
+
+    def __init__(self, guild_id: int = 12345):
+        self.id = guild_id
+        self.name = "Test Guild"
+
+    def get_channel(self, channel_id: int):
+        """Mock get_channel method."""
+        return None
+
+    def get_member(self, user_id: int):
+        """Mock get_member method."""
+        return None
+
+    async def create_voice_channel(self, name: str, category=None, **kwargs):
+        """Mock voice channel creation."""
+        return MockVoiceChannel(channel_id=99999, name=name, category=category)
+
+
+class MockBot:
+    """Mock Discord bot."""
+
+    def __init__(self):
+        self._channels = {}
+        self.guilds = []
+        self.user = MagicMock()
+        self.user.id = 12345
+
+    async def wait_until_ready(self):
+        """Mock wait_until_ready method."""
+        pass
+
+    def get_channel(self, channel_id: int):
+        """Get mock channel by ID."""
+        return self._channels.get(channel_id)
+
+    def add_channel(self, channel: MockVoiceChannel):
+        """Add mock channel."""
+        self._channels[channel.id] = channel
+
+    def remove_channel(self, channel_id: int):
+        """Remove mock channel."""
+        self._channels.pop(channel_id, None)
+
+
+class TestMultipleChannelsPerOwner:
+    """Tests for multiple channels per owner per JTC functionality."""
+
+    @pytest_asyncio.fixture
+    async def voice_service_with_bot(self, temp_db):
+        """Create voice service with mock bot for testing."""
+        config_service = ConfigService()
+        await config_service.initialize()
+
+        mock_bot = MockBot()
+        voice_service = VoiceService(config_service, bot=mock_bot)
+        await voice_service.initialize()
+
+        yield voice_service, mock_bot
+
+        await voice_service.shutdown()
+        await config_service.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_jtc_join_creates_new_channel_when_user_has_existing_active_channel(self, voice_service_with_bot):
+        """Test that joining JTC when user already has a channel creates a new channel."""
+        voice_service, mock_bot = voice_service_with_bot
+
+        # Setup guild and JTC channel
+        guild = MockGuild(guild_id=12345)
+        jtc_channel = MockVoiceChannel(
+            channel_id=67890,
+            name="Join to Create",
+            category=MagicMock()
+        )
+        member = MockMember(user_id=11111, display_name="TestUser")
+
+        # Create an existing active channel for the user
+        existing_channel = MockVoiceChannel(
+            channel_id=55555,
+            name="TestUser's Existing Channel",
+            members=[member]
+        )
+        mock_bot.add_channel(existing_channel)
+
+        # Add existing channel to database
+        async with Database.get_connection() as db:
+            await db.execute(
+                """
+                INSERT INTO voice_channels
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+                (12345, 67890, 11111, 55555, int(time.time()), int(time.time()), 1),
+            )
+            await db.commit()
+
+        # Mock channel permissions check
+        bot_member = MagicMock()
+        bot_member.top_role = MagicMock()
+        bot_member.top_role.name = "bot"
+        member.top_role.name = "member"
+
+        # Mock guild methods
+        guild.get_member = MagicMock(return_value=bot_member)
+
+        # Mock category permissions
+        jtc_channel.category.permissions_for = MagicMock()
+        jtc_channel.category.permissions_for.return_value.manage_channels = True
+
+        # Mock channel creation
+        new_channel = MockVoiceChannel(channel_id=77777, name="TestUser's Channel")
+
+        with patch.object(guild, 'create_voice_channel', return_value=new_channel) as mock_create:
+            with patch('helpers.voice_permissions.enforce_permission_changes') as mock_enforce:
+                with patch('helpers.discord_api.channel_send_message') as mock_send:
+                    # Mock cooldown check to allow creation
+                    with patch.object(voice_service, 'can_create_voice_channel', return_value=(True, None)):
+                        # Call the JTC handler
+                        await voice_service._handle_join_to_create(guild, jtc_channel, member)
+
+                        # Verify a new channel was created (not redirected to existing)
+                        mock_create.assert_called_once()
+
+                        # Verify the member was not moved to existing channel
+                        # (if redirect happened, move_to wouldn't be called on member)
+
+                        # Check database has both channels
+                        async with Database.get_connection() as db:
+                            cursor = await db.execute(
+                                """SELECT COUNT(*) FROM voice_channels 
+                                   WHERE guild_id = ? AND owner_id = ? AND is_active = 1""",
+                                (12345, 11111)
+                            )
+                            count = await cursor.fetchone()
+                            # Should have 2 active channels for the same user
+                            assert count[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_cleanup_by_channel_id_only_affects_specific_channel(self, voice_service_with_bot):
+        """Test that cleanup_by_channel_id only affects the specific channel."""
+        voice_service, mock_bot = voice_service_with_bot
+
+        # Create multiple channels for the same user
+        async with Database.get_connection() as db:
+            # Channel 1
+            await db.execute(
+                """
+                INSERT INTO voice_channels
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+                (12345, 67890, 11111, 55555, int(time.time()), int(time.time()), 1),
+            )
+            # Channel 2
+            await db.execute(
+                """
+                INSERT INTO voice_channels
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+                (12345, 67890, 11111, 66666, int(time.time()), int(time.time()), 1),
+            )
+
+            # Add settings for both channels
+            await db.execute(
+                """
+                INSERT INTO voice_channel_settings
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, setting_key, setting_value)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """,
+                (12345, 67890, 11111, 55555, "channel_name", "Channel 1"),
+            )
+            await db.execute(
+                """
+                INSERT INTO voice_channel_settings
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, setting_key, setting_value)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """,
+                (12345, 67890, 11111, 66666, "channel_name", "Channel 2"),
+            )
+            await db.commit()
+
+        # Cleanup only one channel
+        await voice_service.cleanup_by_channel_id(55555)
+
+        # Verify only one channel was deactivated
+        async with Database.get_connection() as db:
+            cursor = await db.execute(
+                """SELECT is_active FROM voice_channels WHERE voice_channel_id = ?""",
+                (55555,)
+            )
+            channel1_active = await cursor.fetchone()
+            assert channel1_active[0] == 0  # Should be deactivated
+
+            cursor = await db.execute(
+                """SELECT is_active FROM voice_channels WHERE voice_channel_id = ?""",
+                (66666,)
+            )
+            channel2_active = await cursor.fetchone()
+            assert channel2_active[0] == 1  # Should still be active
+
+            # Verify settings were cleaned up only for the specific channel
+            cursor = await db.execute(
+                """SELECT COUNT(*) FROM voice_channel_settings WHERE voice_channel_id = ?""",
+                (55555,)
+            )
+            settings1_count = await cursor.fetchone()
+            assert settings1_count[0] == 0  # Settings should be deleted
+
+            cursor = await db.execute(
+                """SELECT COUNT(*) FROM voice_channel_settings WHERE voice_channel_id = ?""",
+                (66666,)
+            )
+            settings2_count = await cursor.fetchone()
+            assert settings2_count[0] == 1  # Settings should remain
+
+    @pytest.mark.asyncio
+    async def test_get_user_voice_channel_returns_latest_for_jtc(self, voice_service_with_bot):
+        """Test that get_user_voice_channel returns the most recent channel for a JTC."""
+        voice_service, mock_bot = voice_service_with_bot
+
+        # Create multiple channels for the same user and JTC
+        base_time = int(time.time())
+        async with Database.get_connection() as db:
+            # Older channel
+            await db.execute(
+                """
+                INSERT INTO voice_channels
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+                (12345, 67890, 11111, 55555, base_time - 100, base_time - 100, 1),
+            )
+            # Newer channel
+            await db.execute(
+                """
+                INSERT INTO voice_channels
+                (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+                (12345, 67890, 11111, 66666, base_time, base_time, 1),
+            )
+            await db.commit()
+
+        # Get user's channel - should return the newest one
+        channel_id = await voice_service.get_user_voice_channel(12345, 67890, 11111)
+        assert channel_id == 66666  # Should return the newer channel

--- a/tests/test_voice_multiple_channels.py
+++ b/tests/test_voice_multiple_channels.py
@@ -171,8 +171,8 @@ class TestMultipleChannelsPerOwner:
         new_channel = MockVoiceChannel(channel_id=77777, name="TestUser's Channel")
 
         with patch.object(guild, 'create_voice_channel', return_value=new_channel) as mock_create:
-            with patch('helpers.voice_permissions.enforce_permission_changes') as mock_enforce:
-                with patch('helpers.discord_api.channel_send_message') as mock_send:
+            with patch('helpers.voice_permissions.enforce_permission_changes'):
+                with patch('helpers.discord_api.channel_send_message'):
                     # Mock cooldown check to allow creation
                     with patch.object(voice_service, 'can_create_voice_channel', return_value=(True, None)):
                         # Call the JTC handler
@@ -187,7 +187,7 @@ class TestMultipleChannelsPerOwner:
                         # Check database has both channels
                         async with Database.get_connection() as db:
                             cursor = await db.execute(
-                                """SELECT COUNT(*) FROM voice_channels 
+                                """SELECT COUNT(*) FROM voice_channels
                                    WHERE guild_id = ? AND owner_id = ? AND is_active = 1""",
                                 (12345, 11111)
                             )
@@ -198,7 +198,7 @@ class TestMultipleChannelsPerOwner:
     @pytest.mark.asyncio
     async def test_cleanup_by_channel_id_only_affects_specific_channel(self, voice_service_with_bot):
         """Test that cleanup_by_channel_id only affects the specific channel."""
-        voice_service, mock_bot = voice_service_with_bot
+        voice_service, _mock_bot = voice_service_with_bot
 
         # Create multiple channels for the same user
         async with Database.get_connection() as db:
@@ -277,7 +277,7 @@ class TestMultipleChannelsPerOwner:
     @pytest.mark.asyncio
     async def test_get_user_voice_channel_returns_latest_for_jtc(self, voice_service_with_bot):
         """Test that get_user_voice_channel returns the most recent channel for a JTC."""
-        voice_service, mock_bot = voice_service_with_bot
+        voice_service, _mock_bot = voice_service_with_bot
 
         # Create multiple channels for the same user and JTC
         base_time = int(time.time())

--- a/tests/test_voice_owner_command.py
+++ b/tests/test_voice_owner_command.py
@@ -347,8 +347,8 @@ class TestVoiceOwnerCommand:
 
                     for guild_id, jtc_id, owner_id, voice_id, created_at in test_data:
                         await db.execute(
-                            "INSERT INTO user_voice_channels (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at) VALUES (?, ?, ?, ?, ?)",
-                            (guild_id, jtc_id, owner_id, voice_id, created_at),
+                            "INSERT INTO voice_channels (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                            (guild_id, jtc_id, owner_id, voice_id, created_at, created_at, 1),
                         )
                     await db.commit()
 

--- a/tests/test_voice_owner_simple.py
+++ b/tests/test_voice_owner_simple.py
@@ -78,8 +78,8 @@ async def test_voice_owner_command_shows_db_owners():
 
             for guild_id, jtc_id, owner_id, voice_id, created_at in test_data:
                 await db.execute(
-                    "INSERT INTO user_voice_channels (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at) VALUES (?, ?, ?, ?, ?)",
-                    (guild_id, jtc_id, owner_id, voice_id, created_at),
+                    "INSERT INTO voice_channels (guild_id, jtc_channel_id, owner_id, voice_channel_id, created_at, last_activity, is_active) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (guild_id, jtc_id, owner_id, voice_id, created_at, created_at, 1),
                 )
             await db.commit()
 
@@ -163,7 +163,7 @@ async def test_voice_owner_command_shows_db_owners():
             # Clean up test data
             async with Database.get_connection() as db:
                 await db.execute(
-                    "DELETE FROM user_voice_channels WHERE guild_id = ?", (12345,)
+                    "DELETE FROM voice_channels WHERE guild_id = ?", (12345,)
                 )
                 await db.commit()
 

--- a/tests/test_voice_permissions.py
+++ b/tests/test_voice_permissions.py
@@ -126,11 +126,12 @@ async def test_get_user_channel() -> None:
         result = await get_user_channel(bot, user, 1, 101)
         assert result == channel
 
-        # Check SQL query - should not have ORDER BY
+        # Check SQL query - should include is_active filter and ORDER BY LIMIT
         db.execute.assert_called_with(
-            "SELECT voice_channel_id FROM user_voice_channels "
+            "SELECT voice_channel_id FROM voice_channels "
             "WHERE owner_id = ? AND guild_id = ? AND "
-            "jtc_channel_id = ?",
+            "jtc_channel_id = ? AND is_active = 1 "
+            "ORDER BY created_at DESC LIMIT 1",
             (1001, 1, 101),
         )
 
@@ -141,11 +142,11 @@ async def test_get_user_channel() -> None:
         result = await get_user_channel(bot, user, 1)
         assert result == channel
 
-        # Check SQL query - should have ORDER BY
+        # Check SQL query - should include is_active filter and ORDER BY LIMIT
         db.execute.assert_called_with(
-            "SELECT voice_channel_id FROM user_voice_channels "
-            "WHERE owner_id = ? AND guild_id = ? ORDER BY "
-            "created_at DESC",
+            "SELECT voice_channel_id FROM voice_channels "
+            "WHERE owner_id = ? AND guild_id = ? AND is_active = 1 "
+            "ORDER BY created_at DESC LIMIT 1",
             (1001, 1),
         )
 
@@ -156,9 +157,10 @@ async def test_get_user_channel() -> None:
         result = await get_user_channel(bot, user)
         assert result == channel
 
-        # Check SQL query - should have ORDER BY
+        # Check SQL query - should include is_active filter and ORDER BY LIMIT
         db.execute.assert_called_with(
-            "SELECT voice_channel_id FROM user_voice_channels "
-            "WHERE owner_id = ? ORDER BY created_at DESC",
+            "SELECT voice_channel_id FROM voice_channels "
+            "WHERE owner_id = ? AND is_active = 1 "
+            "ORDER BY created_at DESC LIMIT 1",
             (1001,),
         )

--- a/tests/test_voice_reconciliation.py
+++ b/tests/test_voice_reconciliation.py
@@ -125,7 +125,7 @@ class TestVoiceReconciliation:
 
             # Verify channel was removed from database
             mock_db.execute.assert_called_with(
-                "DELETE FROM user_voice_channels WHERE voice_channel_id = ?", (111,)
+                "UPDATE voice_channels SET is_active = 0 WHERE voice_channel_id = ?", (111,)
             )
             mock_db.commit.assert_called_once()
 

--- a/tests/test_voice_settings_deterministic_simple.py
+++ b/tests/test_voice_settings_deterministic_simple.py
@@ -1,0 +1,191 @@
+"""
+Simple tests for deterministic voice settings core functionality.
+
+These tests focus on the database functions and core logic without complex mocking.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from helpers.voice_settings import (
+    _get_available_jtc_channels,
+    _get_last_used_jtc_channel,
+    update_last_used_jtc_channel,
+)
+
+
+class TestDeterministicVoiceSettingsCore:
+    """Test core deterministic voice settings functions."""
+
+    @pytest.mark.asyncio
+    async def test_get_last_used_jtc_channel_found(self, temp_db):
+        """Test _get_last_used_jtc_channel returns the last used JTC channel."""
+        guild_id = 12345
+        user_id = 67890
+        expected_jtc_id = 55555
+
+        with patch("helpers.voice_settings.Database") as mock_db:
+            mock_conn = AsyncMock()
+            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
+
+            cursor = AsyncMock()
+            cursor.fetchone.return_value = (expected_jtc_id,)
+            mock_conn.execute.return_value = cursor
+
+            result = await _get_last_used_jtc_channel(guild_id, user_id)
+
+            assert result == expected_jtc_id
+            # Verify the query was called (exact format doesn't matter for functionality)
+            assert mock_conn.execute.called
+
+    @pytest.mark.asyncio
+    async def test_get_last_used_jtc_channel_not_found(self, temp_db):
+        """Test _get_last_used_jtc_channel returns None when no preference exists."""
+        guild_id = 12345
+        user_id = 67890
+
+        with patch("helpers.voice_settings.Database") as mock_db:
+            mock_conn = AsyncMock()
+            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
+
+            cursor = AsyncMock()
+            cursor.fetchone.return_value = None
+            mock_conn.execute.return_value = cursor
+
+            result = await _get_last_used_jtc_channel(guild_id, user_id)
+
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_last_used_jtc_channel_success(self, temp_db):
+        """Test update_last_used_jtc_channel executes successfully."""
+        guild_id = 12345
+        user_id = 67890
+        jtc_channel_id = 55555
+
+        with patch("helpers.voice_settings.Database") as mock_db:
+            mock_conn = AsyncMock()
+            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
+
+            # Mock the INSERT OR REPLACE operation
+            mock_conn.execute.return_value = AsyncMock()
+            mock_conn.commit.return_value = None
+
+            # Should not raise an exception
+            await update_last_used_jtc_channel(guild_id, user_id, jtc_channel_id)
+
+            # Verify database operations were called
+            assert mock_conn.execute.called
+            assert mock_conn.commit.called
+
+    @pytest.mark.asyncio
+    async def test_get_available_jtc_channels_multiple(self, temp_db):
+        """Test _get_available_jtc_channels returns multiple JTC channels."""
+        guild_id = 12345
+        user_id = 67890
+        expected_jtcs = [11111, 22222, 33333]
+
+        with patch("helpers.voice_settings.Database") as mock_db:
+            mock_conn = AsyncMock()
+            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
+
+            cursor = AsyncMock()
+            cursor.fetchall.return_value = [(jtc,) for jtc in expected_jtcs]
+            mock_conn.execute.return_value = cursor
+
+            result = await _get_available_jtc_channels(guild_id, user_id)
+
+            assert result == expected_jtcs
+
+    @pytest.mark.asyncio
+    async def test_get_available_jtc_channels_none(self, temp_db):
+        """Test _get_available_jtc_channels returns empty list when no JTCs found."""
+        guild_id = 12345
+        user_id = 67890
+
+        with patch("helpers.voice_settings.Database") as mock_db:
+            mock_conn = AsyncMock()
+            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
+
+            cursor = AsyncMock()
+            cursor.fetchall.return_value = []
+            mock_conn.execute.return_value = cursor
+
+            result = await _get_available_jtc_channels(guild_id, user_id)
+
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_deterministic_behavior_consistency(self, temp_db):
+        """Test that the same inputs always produce the same outputs."""
+        guild_id = 12345
+        user_id = 67890
+        jtc_channel_id = 55555
+
+        with patch("helpers.voice_settings.Database") as mock_db:
+            mock_conn = AsyncMock()
+            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
+
+            cursor = AsyncMock()
+            cursor.fetchone.return_value = (jtc_channel_id,)
+            mock_conn.execute.return_value = cursor
+
+            # Call function multiple times with same inputs
+            results = []
+            for _ in range(5):
+                result = await _get_last_used_jtc_channel(guild_id, user_id)
+                results.append(result)
+
+            # Verify all results are identical
+            assert all(result == jtc_channel_id for result in results)
+            assert len(set(results)) == 1  # All results are the same
+
+    @pytest.mark.asyncio
+    async def test_preference_scoping_per_guild_user(self, temp_db):
+        """Test that preferences are properly scoped per (guild_id, user_id)."""
+        with patch("helpers.voice_settings.Database") as mock_db:
+            mock_conn = AsyncMock()
+            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
+
+            # Test that different guild/user combinations can have different preferences
+            test_cases = [
+                (12345, 67890, 11111),  # guild1, user1 -> jtc1
+                (12345, 98765, 22222),  # guild1, user2 -> jtc2
+                (54321, 67890, 33333),  # guild2, user1 -> jtc3
+                (54321, 98765, 44444),  # guild2, user2 -> jtc4
+            ]
+
+            for guild_id, user_id, expected_jtc in test_cases:
+                cursor = AsyncMock()
+                cursor.fetchone.return_value = (expected_jtc,)
+                mock_conn.execute.return_value = cursor
+
+                result = await _get_last_used_jtc_channel(guild_id, user_id)
+                assert result == expected_jtc
+
+    @pytest.mark.asyncio
+    async def test_error_handling_returns_none(self, temp_db):
+        """Test that functions handle database errors gracefully."""
+        guild_id = 12345
+        user_id = 67890
+
+        with patch("helpers.voice_settings.Database") as mock_db:
+            # Simulate a database error
+            mock_db.get_connection.side_effect = Exception("Database error")
+
+            # Should not raise exception, but return None/empty list
+            result1 = await _get_last_used_jtc_channel(guild_id, user_id)
+            assert result1 is None
+
+            result2 = await _get_available_jtc_channels(guild_id, user_id)
+            assert result2 == []
+
+            # update_last_used_jtc_channel should not raise exception
+            try:
+                await update_last_used_jtc_channel(guild_id, user_id, 55555)
+                # If we get here, the function handled the error gracefully
+                assert True
+            except Exception:
+                # If exception is raised, test fails
+                assert False, "Function should handle errors gracefully"

--- a/tests/test_voice_settings_deterministic_simple.py
+++ b/tests/test_voice_settings_deterministic_simple.py
@@ -4,6 +4,7 @@ Simple tests for deterministic voice settings core functionality.
 These tests focus on the database functions and core logic without complex mocking.
 """
 
+from contextlib import nullcontext as does_not_raise
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -182,10 +183,5 @@ class TestDeterministicVoiceSettingsCore:
             assert result2 == []
 
             # update_last_used_jtc_channel should not raise exception
-            try:
+            with does_not_raise():
                 await update_last_used_jtc_channel(guild_id, user_id, 55555)
-                # If we get here, the function handled the error gracefully
-                assert True
-            except Exception:
-                # If exception is raised, test fails
-                assert False, "Function should handle errors gracefully"

--- a/tests/test_voice_settings_integration.py
+++ b/tests/test_voice_settings_integration.py
@@ -185,141 +185,322 @@ class TestVoiceSettingsHelper:
 class TestVoiceServiceChannelCreation:
     """Tests for voice service channel creation with settings loading."""
 
+    @pytest.mark.parametrize("channel_name,user_limit,lock,expected_name,expected_limit", [
+        # Test with saved settings
+        ("My Custom Channel", 5, 1, "My Custom Channel", 5),
+        ("🎮 Gaming Room", 10, 0, "🎮 Gaming Room", 10),
+        ("Valid Channel", 0, 1, "Valid Channel", 0),  # Edge case: zero limit but valid name
+        ("Unicode Channel 你好", 99, 0, "Unicode Channel 你好", 99),
+        # Test with no saved settings (None values)
+        (None, None, None, "TestUser's Channel", 0),  # Should use defaults
+    ])
+    @pytest.mark.asyncio
+    async def test_create_user_channel_parametrized(
+        self, voice_service, mock_guild, mock_jtc_channel, mock_member, mock_db_connection,
+        channel_name, user_limit, lock, expected_name, expected_limit
+    ):
+        """Test _create_user_channel with various saved settings and defaults."""
+        import discord
+
+        # Configure database response
+        if channel_name is None:
+            # No saved settings case
+            mock_db_connection.set_fetchone_result(None)
+        else:
+            # Saved settings case
+            mock_db_connection.set_fetchone_result((channel_name, user_limit, lock))
+
+        # Mock guild.create_voice_channel
+        created_channel = AsyncMock(spec=discord.VoiceChannel)
+        created_channel.id = 99999
+        created_channel.name = expected_name
+        mock_guild.create_voice_channel.return_value = created_channel
+
+        # Mock member move
+        mock_member.move_to = AsyncMock()
+
+        # Mock bot member for role comparison
+        mock_bot_member = MagicMock()
+        mock_bot_member.top_role = MagicMock()
+        mock_bot_member.top_role.__gt__ = MagicMock(return_value=True)
+        mock_guild.get_member.return_value = mock_bot_member
+
+        # Mock enforce_permission_changes and channel_send_message
+        with patch("services.voice_service.enforce_permission_changes") as mock_enforce, \
+             patch("services.voice_service.channel_send_message") as mock_send:
+
+            mock_enforce.return_value = None
+            mock_send.return_value = None
+
+            await voice_service._create_user_channel(
+                mock_guild, mock_jtc_channel, mock_member
+            )
+
+            # Verify channel was created with expected settings
+            mock_guild.create_voice_channel.assert_called_once()
+            create_args = mock_guild.create_voice_channel.call_args
+
+            assert create_args.kwargs["name"] == expected_name
+
+            # For no saved settings, should use JTC channel's user_limit
+            if channel_name is None:
+                assert create_args.kwargs["user_limit"] == mock_jtc_channel.user_limit
+            else:
+                assert create_args.kwargs["user_limit"] == expected_limit
+
+    @pytest.mark.asyncio
+    async def test_create_user_channel_empty_name_fallback(
+        self, voice_service, mock_guild, mock_jtc_channel, mock_member, mock_db_connection
+    ):
+        """Test that empty channel names fall back to default."""
+        import discord
+
+        # Test case: saved settings with empty name should fall back to default
+        mock_db_connection.set_fetchone_result(("", 5, 1))
+
+        # Mock guild.create_voice_channel
+        created_channel = AsyncMock(spec=discord.VoiceChannel)
+        created_channel.id = 99999
+        created_channel.name = "TestUser's Channel"
+        mock_guild.create_voice_channel.return_value = created_channel
+
+        # Mock member move
+        mock_member.move_to = AsyncMock()
+
+        # Mock bot member for role comparison
+        mock_bot_member = MagicMock()
+        mock_bot_member.top_role = MagicMock()
+        mock_bot_member.top_role.__gt__ = MagicMock(return_value=True)
+        mock_guild.get_member.return_value = mock_bot_member
+
+        # Mock enforce_permission_changes and channel_send_message
+        with patch("services.voice_service.enforce_permission_changes") as mock_enforce, \
+             patch("services.voice_service.channel_send_message") as mock_send:
+
+            mock_enforce.return_value = None
+            mock_send.return_value = None
+
+            await voice_service._create_user_channel(
+                mock_guild, mock_jtc_channel, mock_member
+            )
+
+            # Verify channel was created with fallback name
+            mock_guild.create_voice_channel.assert_called_once()
+            create_args = mock_guild.create_voice_channel.call_args
+
+            assert create_args.kwargs["name"] == "TestUser's Channel"  # Should fallback to default
+            assert create_args.kwargs["user_limit"] == 5  # Should use saved limit
+
     @pytest.mark.asyncio
     async def test_create_user_channel_applies_saved_settings(
-        self, voice_service, mock_guild, mock_jtc_channel, mock_member
+        self, voice_service, mock_guild, mock_jtc_channel, mock_member, mock_db_connection
     ):
         """Test that _create_user_channel applies saved settings during creation."""
+        import discord
 
-        # Mock the saved settings
+        # Configure saved settings
+        mock_db_connection.set_fetchone_result(("My Custom Channel", 5, 1))
 
-        # Mock database interaction
-        with patch("services.voice_service.Database") as mock_db:
-            mock_conn = AsyncMock()
-            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
+        # Mock guild.create_voice_channel
+        created_channel = AsyncMock(spec=discord.VoiceChannel)
+        created_channel.id = 99999
+        created_channel.name = "My Custom Channel"
+        mock_guild.create_voice_channel.return_value = created_channel
 
-            cursor = AsyncMock()
-            cursor.fetchone.return_value = ("My Custom Channel", 5, 1)
-            mock_conn.execute.return_value = cursor
+        # Mock member move
+        mock_member.move_to = AsyncMock()
 
-            # Mock guild.create_voice_channel
-            created_channel = AsyncMock(spec=discord.VoiceChannel)
-            created_channel.id = 99999
-            created_channel.name = "My Custom Channel"
-            mock_guild.create_voice_channel.return_value = created_channel
+        # Mock enforce_permission_changes
+        with patch(
+            "services.voice_service.enforce_permission_changes"
+        ) as mock_enforce:
+            mock_enforce.return_value = None
 
-            # Mock member move
-            mock_member.move_to = AsyncMock()
+            # Mock channel_send_message
+            with patch("services.voice_service.channel_send_message") as mock_send:
+                mock_send.return_value = None
 
-            # Mock enforce_permission_changes
-            with patch(
-                "services.voice_service.enforce_permission_changes"
-            ) as mock_enforce:
-                mock_enforce.return_value = None
+                await voice_service._create_user_channel(
+                    mock_guild, mock_jtc_channel, mock_member
+                )
 
-                # Mock channel_send_message
-                with patch("services.voice_service.channel_send_message") as mock_send:
-                    mock_send.return_value = None
+                # Verify channel was created with saved settings
+                mock_guild.create_voice_channel.assert_called_once()
+                create_args = mock_guild.create_voice_channel.call_args
 
-                    await voice_service._create_user_channel(
-                        mock_guild, mock_jtc_channel, mock_member
-                    )
+                assert create_args.kwargs["name"] == "My Custom Channel"
+                assert create_args.kwargs["user_limit"] == 5
 
-                    # Verify channel was created with saved settings
-                    mock_guild.create_voice_channel.assert_called_once()
-                    create_args = mock_guild.create_voice_channel.call_args
+                # Verify settings were applied
+                mock_enforce.assert_called_once()
 
-                    assert create_args.kwargs["name"] == "My Custom Channel"
-                    assert create_args.kwargs["user_limit"] == 5
-
-                    # Verify settings were applied
-                    mock_enforce.assert_called_once()
-
-                    # Verify ChannelSettingsView was posted
-                    mock_send.assert_called_once()
+                # Verify ChannelSettingsView was posted
+                mock_send.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_create_user_channel_uses_defaults_no_saved_settings(
-        self, voice_service, mock_guild, mock_jtc_channel, mock_member
+        self, voice_service, mock_guild, mock_jtc_channel, mock_member, mock_db_connection
     ):
         """Test that _create_user_channel uses defaults when no saved settings exist."""
+        import discord
 
         # Mock no saved settings
-        with patch("services.voice_service.Database") as mock_db:
-            mock_conn = AsyncMock()
-            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
+        mock_db_connection.set_fetchone_result(None)
 
-            cursor = AsyncMock()
-            cursor.fetchone.return_value = None  # No saved settings
-            mock_conn.execute.return_value = cursor
+        # Mock guild.create_voice_channel
+        created_channel = AsyncMock(spec=discord.VoiceChannel)
+        created_channel.id = 99999
+        mock_guild.create_voice_channel.return_value = created_channel
 
-            # Mock guild.create_voice_channel
-            created_channel = AsyncMock(spec=discord.VoiceChannel)
-            created_channel.id = 99999
-            mock_guild.create_voice_channel.return_value = created_channel
+        # Mock member move
+        mock_member.move_to = AsyncMock()
 
-            # Mock member move
-            mock_member.move_to = AsyncMock()
+        # Mock enforce_permission_changes
+        with patch("services.voice_service.enforce_permission_changes"):
+            # Mock channel_send_message
+            with patch("services.voice_service.channel_send_message"):
+                await voice_service._create_user_channel(
+                    mock_guild, mock_jtc_channel, mock_member
+                )
 
-            # Mock enforce_permission_changes
-            with patch("services.voice_service.enforce_permission_changes"):
-                # Mock channel_send_message
-                with patch("services.voice_service.channel_send_message"):
-                    await voice_service._create_user_channel(
-                        mock_guild, mock_jtc_channel, mock_member
-                    )
+                # Verify channel was created with default settings
+                mock_guild.create_voice_channel.assert_called_once()
+                create_args = mock_guild.create_voice_channel.call_args
 
-                    # Verify channel was created with default settings
-                    mock_guild.create_voice_channel.assert_called_once()
-                    create_args = mock_guild.create_voice_channel.call_args
+                # Should use default name format
+                assert (
+                    create_args.kwargs["name"]
+                    == f"{mock_member.display_name}'s Channel"
+                )
+                # Should use JTC channel's user_limit
+                assert (
+                    create_args.kwargs["user_limit"] == mock_jtc_channel.user_limit
+                )
 
-                    # Should use default name format
-                    assert (
-                        create_args.kwargs["name"]
-                        == f"{mock_member.display_name}'s Channel"
-                    )
-                    # Should use JTC channel's user_limit
-                    assert (
-                        create_args.kwargs["user_limit"] == mock_jtc_channel.user_limit
-                    )
-
+    @pytest.mark.parametrize("channel_name,user_limit,lock,expected_name,expected_limit,expected_lock", [
+        # Test various valid settings
+        ("Custom Name", 10, 0, "Custom Name", 10, False),
+        ("🎮 Gaming Channel", 5, 1, "🎮 Gaming Channel", 5, True),
+        ("Test Channel with Unicode 你好", 99, 0, "Test Channel with Unicode 你好", 99, False),
+        # Test edge cases
+        ("", 0, 1, "", 0, True),  # Empty name, zero limit
+        ("Very Long Channel Name That Exceeds Normal Limits", 1, 0, "Very Long Channel Name That Exceeds Normal Limits", 1, False),
+        # Test defaults/None handling
+        (None, None, None, None, None, None),  # All None values
+    ])
     @pytest.mark.asyncio
-    async def test_load_channel_settings_success(self, voice_service):
-        """Test _load_channel_settings returns settings when they exist."""
-        with patch("services.voice_service.Database") as mock_db:
-            mock_conn = AsyncMock()
-            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
-
-            cursor = AsyncMock()
-            cursor.fetchone.return_value = ("Custom Name", 10, 0)
-            mock_conn.execute.return_value = cursor
-
+    async def test_load_channel_settings_parametrized(
+        self, voice_service, mock_db_connection,
+        channel_name, user_limit, lock, expected_name, expected_limit, expected_lock
+    ):
+        """Test _load_channel_settings with various parameter combinations."""
+        if channel_name is None:
+            # Test case where no settings exist
+            mock_db_connection.set_fetchone_result(None)
             settings = await voice_service._load_channel_settings(12345, 55555, 67890)
-
-            assert settings["channel_name"] == "Custom Name"
-            assert settings["user_limit"] == 10
-            assert settings["lock"] == 0
-
-    @pytest.mark.asyncio
-    async def test_load_channel_settings_no_settings(self, voice_service):
-        """Test _load_channel_settings returns None when no settings exist."""
-        with patch("services.voice_service.Database") as mock_db:
-            mock_conn = AsyncMock()
-            mock_db.get_connection.return_value.__aenter__.return_value = mock_conn
-
-            cursor = AsyncMock()
-            cursor.fetchone.return_value = None
-            mock_conn.execute.return_value = cursor
-
-            settings = await voice_service._load_channel_settings(12345, 55555, 67890)
-
             assert settings is None
+        else:
+            # Test case where settings exist
+            mock_db_connection.set_fetchone_result((channel_name, user_limit, lock))
+            settings = await voice_service._load_channel_settings(12345, 55555, 67890)
+
+            assert settings["channel_name"] == expected_name
+            assert settings["user_limit"] == expected_limit
+            assert settings["lock"] == expected_lock
+
+    @pytest.mark.asyncio
+    async def test_load_channel_settings_success(self, voice_service, mock_db_connection):
+        """Test _load_channel_settings returns settings when they exist."""
+        mock_db_connection.set_fetchone_result(("Custom Name", 10, 0))
+
+        settings = await voice_service._load_channel_settings(12345, 55555, 67890)
+
+        assert settings["channel_name"] == "Custom Name"
+        assert settings["user_limit"] == 10
+        assert settings["lock"] == 0
+
+    @pytest.mark.asyncio
+    async def test_load_channel_settings_no_settings(self, voice_service, mock_db_connection):
+        """Test _load_channel_settings returns None when no settings exist."""
+        mock_db_connection.set_fetchone_result(None)
+
+        settings = await voice_service._load_channel_settings(12345, 55555, 67890)
+
+        assert settings is None
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
-async def test_voice_command_integration():
-    """Integration test to verify voice commands work with the new helper."""
-    # This would be a more complex integration test
-    # Testing the actual command interaction would require more setup
-    # but this demonstrates the test pattern
-    pass
+async def test_voice_command_integration(voice_service, mock_db_connection):
+    """Integration test to verify voice command flow with fake Discord objects."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import discord
+
+    # Create fake Discord objects
+    fake_guild = MagicMock(spec=discord.Guild)
+    fake_guild.id = 12345
+    fake_guild.name = "Test Squadron"
+
+    fake_member = MagicMock(spec=discord.Member)
+    fake_member.id = 67890
+    fake_member.display_name = "TestPilot"
+    fake_member.guild = fake_guild
+
+    # Create fake category for the JTC channel
+    fake_category = MagicMock(spec=discord.CategoryChannel)
+    fake_category.id = 44444
+    fake_category.name = "Voice Channels"
+
+    fake_jtc_channel = MagicMock(spec=discord.VoiceChannel)
+    fake_jtc_channel.id = 55555
+    fake_jtc_channel.name = "Join to Create"
+    fake_jtc_channel.user_limit = 0
+    fake_jtc_channel.category = fake_category
+    fake_jtc_channel.bitrate = 64000
+
+    fake_created_channel = AsyncMock(spec=discord.VoiceChannel)
+    fake_created_channel.id = 99999
+    fake_created_channel.name = "TestPilot's Channel"
+
+    # Mock the guild's channel creation
+    fake_guild.create_voice_channel.return_value = fake_created_channel
+
+    # Mock member move functionality
+    fake_member.move_to = AsyncMock()
+
+    # Mock bot member for role comparison
+    fake_bot_member = MagicMock()
+    fake_bot_member.top_role = MagicMock()
+    fake_bot_member.top_role.__gt__ = MagicMock(return_value=True)
+    fake_guild.get_member.return_value = fake_bot_member
+
+    # Set up database mock - no saved settings for this test
+    mock_db_connection.set_fetchone_result(None)
+
+    # Mock permission enforcement and messaging
+    with patch("services.voice_service.enforce_permission_changes") as mock_enforce, \
+         patch("services.voice_service.channel_send_message") as mock_send:
+
+        mock_enforce.return_value = None
+        mock_send.return_value = None
+
+        # Execute the voice service flow: join-to-create → create channel → move member
+        await voice_service._create_user_channel(fake_guild, fake_jtc_channel, fake_member)
+
+        # Verify the integration flow worked
+        # 1. Channel was created with default name (no saved settings)
+        fake_guild.create_voice_channel.assert_called_once()
+        create_call = fake_guild.create_voice_channel.call_args
+        assert create_call.kwargs["name"] == "TestPilot's Channel"
+        assert create_call.kwargs["user_limit"] == fake_jtc_channel.user_limit
+        assert create_call.kwargs["category"] == fake_category
+
+        # 2. Member was moved to the new channel
+        fake_member.move_to.assert_called_once_with(fake_created_channel)
+
+        # 3. Permissions were enforced
+        mock_enforce.assert_called_once()
+
+        # 4. Settings view was sent to channel
+        mock_send.assert_called_once()

--- a/tests/test_voice_strict_scoping.py
+++ b/tests/test_voice_strict_scoping.py
@@ -1,0 +1,276 @@
+"""
+Tests for strict voice settings scoping per JTC/guild/user.
+
+Ensures voice settings are properly scoped to (guild_id, jtc_channel_id, user_id) and 
+there's no unintended bleeding between JTCs.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from helpers.voice_permissions import (
+    _apply_lock_setting,
+    _apply_permit_reject_settings,
+    _apply_voice_feature_settings,
+)
+from helpers.voice_settings import _get_all_user_settings
+from helpers.voice_utils import update_channel_settings
+from services.voice_service import VoiceService
+
+
+@pytest.fixture
+def mock_bot():
+    """Create a mock Discord bot."""
+    bot = MagicMock(spec=discord.Client)
+    return bot
+
+
+@pytest.fixture
+def mock_guild():
+    """Create a mock Discord guild."""
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 12345
+    guild.default_role = MagicMock(spec=discord.Role)
+    guild.default_role.id = 99999
+    return guild
+
+
+@pytest.fixture
+def mock_user():
+    """Create a mock Discord user."""
+    user = MagicMock(spec=discord.Member)
+    user.id = 67890
+    user.display_name = "TestUser"
+    return user
+
+
+@pytest.fixture
+def mock_voice_channel():
+    """Create a mock Discord voice channel."""
+    channel = MagicMock(spec=discord.VoiceChannel)
+    channel.id = 111
+    channel.name = "Test Channel"
+    channel.user_limit = 5
+    channel.overwrites = {}
+    return channel
+
+
+class TestStrictScoping:
+    """Test strict scoping behavior for voice settings."""
+
+    @pytest.mark.asyncio
+    async def test_voice_service_load_settings_strict_scope(self, mock_bot, mock_guild, mock_user, mock_db_connection):
+        """Test that voice service only loads settings with exact guild/JTC match."""
+        voice_service = VoiceService(mock_bot)
+        guild_id = 12345
+        jtc_channel_id = 100
+        user_id = 67890
+
+        # Configure mock to return settings for exact match
+        mock_db_connection.set_fetchone_result(("Test Channel", 10, 1))
+        mock_db_connection.set_fetchall_result([(user_id, "user", "permit")])
+
+        settings = await voice_service._load_channel_settings(guild_id, jtc_channel_id, user_id)
+
+        # Verify queries are made with strict scoping
+        calls = mock_db_connection.get_connection_calls()
+        for call in calls:
+            query = call[0][0]
+            params = call[0][1]
+            if "WHERE" in query:
+                # All queries should have guild_id, jtc_channel_id, user_id
+                assert guild_id in params
+                assert jtc_channel_id in params
+                assert user_id in params
+
+    @pytest.mark.asyncio
+    async def test_permit_reject_settings_strict_scope(self, mock_voice_channel, mock_guild):
+        """Test that permit/reject settings only apply with exact guild/JTC match."""
+        guild_id = 12345
+        jtc_channel_id = 100
+        user_id = 67890
+
+        with patch('services.db.database.Database.get_connection') as mock_db:
+            mock_conn = AsyncMock()
+            mock_cursor = AsyncMock()
+            mock_db.return_value.__aenter__.return_value = mock_conn
+            mock_conn.execute.return_value = mock_cursor
+
+            # Mock query returns permissions for exact match only
+            mock_cursor.fetchall.return_value = [(user_id, "user", "permit")]
+
+            overwrites = {}
+            await _apply_permit_reject_settings(overwrites, mock_guild, user_id, guild_id, jtc_channel_id)
+
+            # Verify query uses strict scoping
+            query_call = mock_conn.execute.call_args_list[0]
+            query = query_call[0][0]
+            params = query_call[0][1]
+
+            assert "WHERE" in query
+            assert guild_id in params
+            assert jtc_channel_id in params
+            assert user_id in params
+
+    @pytest.mark.asyncio
+    async def test_voice_feature_settings_strict_scope(self, mock_voice_channel, mock_guild):
+        """Test that voice feature settings only apply with exact guild/JTC match."""
+        guild_id = 12345
+        jtc_channel_id = 100
+        user_id = 67890
+
+        with patch('services.db.database.Database.get_connection') as mock_db:
+            mock_conn = AsyncMock()
+            mock_cursor = AsyncMock()
+            mock_db.return_value.__aenter__.return_value = mock_conn
+            mock_conn.execute.return_value = mock_cursor
+
+            # Mock query returns feature settings for exact match only
+            mock_cursor.fetchall.return_value = [(user_id, "user", 1)]
+
+            overwrites = {}
+            await _apply_voice_feature_settings(
+                overwrites, mock_guild, user_id, guild_id, jtc_channel_id
+            )
+
+            # Verify query uses strict scoping
+            query_call = mock_conn.execute.call_args_list[0]
+            query = query_call[0][0]
+            params = query_call[0][1]
+
+            assert "WHERE" in query
+            assert guild_id in params
+            assert jtc_channel_id in params
+            assert user_id in params
+
+    @pytest.mark.asyncio
+    async def test_lock_setting_strict_scope(self, mock_voice_channel, mock_guild):
+        """Test that lock settings only apply with exact guild/JTC match."""
+        guild_id = 12345
+        jtc_channel_id = 100
+        user_id = 67890
+
+        with patch('services.db.database.Database.get_connection') as mock_db:
+            mock_conn = AsyncMock()
+            mock_cursor = AsyncMock()
+            mock_db.return_value.__aenter__.return_value = mock_conn
+            mock_conn.execute.return_value = mock_cursor
+
+            # Mock query returns lock setting for exact match only
+            mock_cursor.fetchone.return_value = (1,)
+
+            overwrites = {}
+            await _apply_lock_setting(overwrites, mock_guild, user_id, guild_id, jtc_channel_id)
+
+            # Verify query uses strict scoping
+            query_call = mock_conn.execute.call_args_list[0]
+            query = query_call[0][0]
+            params = query_call[0][1]
+
+            assert "WHERE" in query
+            assert guild_id in params
+            assert jtc_channel_id in params
+            assert user_id in params
+
+    @pytest.mark.asyncio
+    async def test_get_all_user_settings_strict_scope(self):
+        """Test that _get_all_user_settings only queries with exact guild/JTC match."""
+        guild_id = 12345
+        jtc_channel_id = 100
+        user_id = 67890
+
+        with patch('services.db.database.Database.get_connection') as mock_db:
+            mock_conn = AsyncMock()
+            mock_cursor = AsyncMock()
+            mock_db.return_value.__aenter__.return_value = mock_conn
+            mock_conn.execute.return_value = mock_cursor
+
+            # Mock all queries return data for exact match only
+            mock_cursor.fetchone.return_value = ("Test Channel", 10, 1)
+            mock_cursor.fetchall.return_value = [(user_id, "user", "permit")]
+
+            settings = await _get_all_user_settings(guild_id, jtc_channel_id, user_id)
+
+            # Verify all queries use strict scoping
+            calls = mock_conn.execute.call_args_list
+            for call in calls:
+                query = call[0][0]
+                params = call[0][1]
+                if "WHERE" in query:
+                    # All queries should have guild_id, jtc_channel_id, user_id
+                    assert guild_id in params
+                    assert jtc_channel_id in params
+                    assert user_id in params
+
+    @pytest.mark.asyncio
+    async def test_update_channel_settings_requires_guild_and_jtc(self):
+        """Test that update_channel_settings requires both guild_id and jtc_channel_id."""
+        user_id = 67890
+
+        # Test missing guild_id
+        with patch('helpers.voice_utils.logger') as mock_logger:
+            await update_channel_settings(user_id, guild_id=None, jtc_channel_id=100, channel_name="Test")
+            mock_logger.error.assert_called_once()
+
+        # Test missing jtc_channel_id
+        with patch('helpers.voice_utils.logger') as mock_logger:
+            await update_channel_settings(user_id, guild_id=12345, jtc_channel_id=None, channel_name="Test")
+            mock_logger.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_voice_feature_setting_requires_guild_and_jtc(self):
+        """Test that set_voice_feature_setting requires both guild_id and jtc_channel_id."""
+        from helpers.voice_utils import set_voice_feature_setting
+
+        user_id = 67890
+        target_id = 12345
+
+        # Test missing guild_id
+        with patch('helpers.voice_utils.logger') as mock_logger:
+            await set_voice_feature_setting(
+                "ptt", user_id, target_id, "user", True, guild_id=None, jtc_channel_id=100
+            )
+            mock_logger.error.assert_called_once()
+
+        # Test missing jtc_channel_id
+        with patch('helpers.voice_utils.logger') as mock_logger:
+            await set_voice_feature_setting(
+                "ptt", user_id, target_id, "user", True, guild_id=12345, jtc_channel_id=None
+            )
+            mock_logger.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_settings_bleeding_between_jtcs(self):
+        """Test that settings for one JTC don't bleed into another JTC."""
+        guild_id = 12345
+        jtc_channel_id_1 = 100
+        jtc_channel_id_2 = 200
+        user_id = 67890
+
+        with patch('services.db.database.Database.get_connection') as mock_db:
+            mock_conn = AsyncMock()
+            mock_cursor = AsyncMock()
+            mock_db.return_value.__aenter__.return_value = mock_conn
+            mock_conn.execute.return_value = mock_cursor
+
+            # Mock query for JTC 1 returns settings
+            mock_cursor.fetchone.return_value = ("JTC1 Channel", 10, 1)
+            mock_cursor.fetchall.return_value = [(user_id, "user", "permit")]
+
+            settings_jtc1 = await _get_all_user_settings(guild_id, jtc_channel_id_1, user_id)
+
+            # Mock query for JTC 2 returns no settings (None/empty)
+            mock_cursor.fetchone.return_value = None
+            mock_cursor.fetchall.return_value = []
+
+            settings_jtc2 = await _get_all_user_settings(guild_id, jtc_channel_id_2, user_id)
+
+            # Verify JTC1 has settings but JTC2 doesn't (no fallback)
+            assert settings_jtc1.get("channel_name") == "JTC1 Channel"
+            assert settings_jtc1.get("permissions") == [(user_id, "user", "permit")]
+
+            # JTC2 should have no settings since there's no fallback
+            assert "channel_name" not in settings_jtc2
+            assert "permissions" not in settings_jtc2

--- a/tests/test_voice_strict_scoping.py
+++ b/tests/test_voice_strict_scoping.py
@@ -1,7 +1,7 @@
 """
 Tests for strict voice settings scoping per JTC/guild/user.
 
-Ensures voice settings are properly scoped to (guild_id, jtc_channel_id, user_id) and 
+Ensures voice settings are properly scoped to (guild_id, jtc_channel_id, user_id) and
 there's no unintended bleeding between JTCs.
 """
 
@@ -23,8 +23,7 @@ from services.voice_service import VoiceService
 @pytest.fixture
 def mock_bot():
     """Create a mock Discord bot."""
-    bot = MagicMock(spec=discord.Client)
-    return bot
+    return MagicMock(spec=discord.Client)
 
 
 @pytest.fixture
@@ -72,7 +71,7 @@ class TestStrictScoping:
         mock_db_connection.set_fetchone_result(("Test Channel", 10, 1))
         mock_db_connection.set_fetchall_result([(user_id, "user", "permit")])
 
-        settings = await voice_service._load_channel_settings(guild_id, jtc_channel_id, user_id)
+        await voice_service._load_channel_settings(guild_id, jtc_channel_id, user_id)
 
         # Verify queries are made with strict scoping
         calls = mock_db_connection.get_connection_calls()
@@ -191,7 +190,7 @@ class TestStrictScoping:
             mock_cursor.fetchone.return_value = ("Test Channel", 10, 1)
             mock_cursor.fetchall.return_value = [(user_id, "user", "permit")]
 
-            settings = await _get_all_user_settings(guild_id, jtc_channel_id, user_id)
+            await _get_all_user_settings(guild_id, jtc_channel_id, user_id)
 
             # Verify all queries use strict scoping
             calls = mock_conn.execute.call_args_list

--- a/tests/test_voice_strict_scoping.py
+++ b/tests/test_voice_strict_scoping.py
@@ -77,8 +77,8 @@ class TestStrictScoping:
         calls = mock_db_connection.get_connection_calls()
         for call in calls:
             query = call[0][0]
-            params = call[0][1]
             if "WHERE" in query:
+                params = call[0][1]
                 # All queries should have guild_id, jtc_channel_id, user_id
                 assert guild_id in params
                 assert jtc_channel_id in params
@@ -196,8 +196,8 @@ class TestStrictScoping:
             calls = mock_conn.execute.call_args_list
             for call in calls:
                 query = call[0][0]
-                params = call[0][1]
                 if "WHERE" in query:
+                    params = call[0][1]
                     # All queries should have guild_id, jtc_channel_id, user_id
                     assert guild_id in params
                     assert jtc_channel_id in params

--- a/tests/test_voice_ui_fix.py
+++ b/tests/test_voice_ui_fix.py
@@ -1,3 +1,0 @@
-# Placeholder test moved from repository root
-def test_placeholder():
-    assert True

--- a/tests/test_voice_ui_simple.py
+++ b/tests/test_voice_ui_simple.py
@@ -1,3 +1,0 @@
-# Placeholder test moved from repository root
-def test_placeholder():
-    assert True

--- a/tools/rsi_probe.py
+++ b/tools/rsi_probe.py
@@ -8,16 +8,16 @@ Mirrors the bot's production HTTP calls exactly - same User-Agent, timeout, and 
 Examples:
   Production parity test (default):
     python tools/rsi_probe.py --handles HyperZonic,OverlordCustomsLLC,squeakytoy --no-warmup
-  
+
   Test with old User-Agent:
     python tools/rsi_probe.py --handles HyperZonic --no-warmup --user-agent "Mozilla/5.0 TESTBot"
-  
+
   Canonical-path experiment:
     python tools/rsi_probe.py --handles HyperZonic --no-warmup --try-en --save-bodies rsi_out
-  
+
   Comprehensive 403 detection tests:
     python tools/rsi_probe.py --test-403 --handles HANDLE1,HANDLE2,HANDLE3
-  
+
   Live tests:
     python -m pip install requests pytest
     RSI_LIVE=1 pytest -v tests/test_rsi_live_probe.py
@@ -45,7 +45,7 @@ def create_session(user_agent: str = "TEST-Squadron-Verification-Bot/1.0 (+https
 def fetch(session: requests.Session, url: str) -> dict[str, Any]:
     """
     Centralized GET helper with 15s timeout and production-like settings.
-    
+
     Returns:
         Dict with status, body, headers, history, final_url, content_type, redirected
     """
@@ -79,10 +79,10 @@ def warmup(session: requests.Session) -> bool:
     """
     Perform a warm-up GET on the RSI homepage.
     Only used when --no-warmup is not set.
-    
+
     Args:
         session: The requests session to use
-        
+
     Returns:
         True if warmup was successful, False otherwise
     """
@@ -267,13 +267,13 @@ def probe_handle(session: requests.Session, handle: str, try_en: bool = False,
                 save_bodies_dir: str | None = None) -> dict[str, Any]:
     """
     Probe a specific RSI handle for citizen and organization pages.
-    
+
     Args:
         session: The requests session to use
         handle: The RSI handle to probe
         try_en: If True, also probe /en/citizens/... variants
         save_bodies_dir: Directory to save bodies for problematic responses
-        
+
     Returns:
         Dictionary containing probe results with new structure
     """
@@ -364,7 +364,7 @@ def print_report(results: list[dict[str, Any]]) -> None:
     for result in results:
         handle = result['handle']
         endpoints = result['endpoints']
-        summary = result['summary']
+        result['summary']
 
         print(f"\n🎯 Handle: {handle}")
         print("-" * 40)
@@ -507,7 +507,7 @@ def main():
 Examples:
   Parity run (most realistic vs. bot):
     %(prog)s --handles HyperZonic,OverlordCustomsLLC,squeakytoy --no-warmup --user-agent "Mozilla/5.0 TESTBot"
-  
+
   Canonical-path experiment:
     %(prog)s --handles HyperZonic --no-warmup --try-en --save-bodies rsi_out
         """,
@@ -577,9 +577,8 @@ Examples:
     session = create_session(args.user_agent)
 
     # Warmup if not disabled
-    if not args.no_warmup:
-        if not warmup(session):
-            print("❌ Warmup failed. Continuing anyway, but results may be unreliable.")
+    if not args.no_warmup and not warmup(session):
+        print("❌ Warmup failed. Continuing anyway, but results may be unreliable.")
 
     # Probe each handle
     results = []


### PR DESCRIPTION
### **User description**
Improve test coverage and SQL safety by updating dependencies, refining test patterns, and enhancing database migration checks. This includes adding integration test markers and optimizing CI processes for better performance. Additionally, ensure voice service logging is improved and SQL queries are safeguarded against injection risks.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
• **Major database schema refactor**: Migrated from `user_voice_channels` to `voice_channels` table to support multiple channels per owner per JTC
• **Enhanced voice service functionality**: Removed existing channel checks to allow multiple channels per user, added debug logging, and improved channel creation flow
• **Comprehensive test coverage expansion**: Added extensive test suites for multiple channels, strict scoping, deterministic settings, and integration scenarios
• **Database migration support**: Added migration script and utilities to transform existing data to new schema with proper indexing
• **CI/CD improvements**: Enhanced workflows with coverage reporting, added `pytest-cov` and `requests` dependencies
• **Code quality fixes**: Resolved unused variable warnings across multiple files with proper underscore prefixes
• **Configuration updates**: Added integration test markers, VSCode tasks, and pytest configuration enhancements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Schema: user_voice_channels"] --> B["Database Migration"]
  B --> C["New Schema: voice_channels + user_jtc_preferences"]
  C --> D["Enhanced Voice Service"]
  D --> E["Multiple Channels Per Owner"]
  F["Test Suite Expansion"] --> G["Integration Tests"]
  F --> H["Multiple Channel Tests"]
  F --> I["Strict Scoping Tests"]
  J["CI/CD Updates"] --> K["Coverage Reporting"]
  J --> L["New Dependencies"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>voice_service.py</strong><dd><code>Refactor voice service for multiple channels per owner support</code></dd></summary>
<hr>

services/voice_service.py

• Refactored database schema from <code>user_voice_channels</code> to <br><code>voice_channels</code> table with support for multiple channels per owner per <br>JTC<br> • Removed existing channel check in <code>can_create_voice_channel</code> to <br>allow multiple channels per user<br> • Added debug logging configuration <br>and enhanced channel creation logging<br> • Updated database cleanup <br>methods to use <code>cleanup_by_channel_id</code> for channel-specific operations<br> • <br>Added function alias <code>update_last_used_jtc_channel</code> to avoid circular <br>imports


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-de5c75e3d5faa21b605e243fba215404a007bf5e168bd6fc557cda5d6b489d48">+138/-92</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>voice_utils.py</strong><dd><code>Update voice utilities for new database schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helpers/voice_utils.py

• Updated database queries to use <code>voice_channels</code> table instead of <br><code>user_voice_channels</code><br> • Added <code>is_active = 1</code> filters and <code>ORDER BY </code><br><code>created_at DESC LIMIT 1</code> for deterministic channel selection<br> • Made <br><code>guild_id</code> and <code>jtc_channel_id</code> required parameters for settings functions<br> <br>• Removed legacy mode support for backward compatibility


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-4d347599a99957fa52e5deac9eb22274690c96fbdcaa5ce470d2c23e8656be21">+49/-167</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>voice_settings.py</strong><dd><code>Implement deterministic JTC channel selection in voice settings</code></dd></summary>
<hr>

helpers/voice_settings.py

• Updated database queries to use <code>voice_channels</code> table with <code>is_active </code><br><code>= 1</code> filters<br> • Added deterministic JTC channel selection using last <br>used JTC preferences<br> • Implemented functions for tracking and updating <br>user JTC preferences<br> • Enhanced user settings display with multiple <br>JTC channel support


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-2173773d002372230ff2ac5376f55d6eb690f371cb1d0fe1bd978daf19b30875">+98/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>voice_repo.py</strong><dd><code>Update voice repository for new database schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helpers/voice_repo.py

• Updated all database queries to use <code>voice_channels</code> table instead of <br><code>user_voice_channels</code><br> • Added <code>is_active = 1</code> filters and <code>ORDER BY </code><br><code>created_at DESC LIMIT 1</code> for consistent channel selection<br> • Updated <br>channel ownership transfer and cleanup operations for new schema<br> • <br>Modified user data cleanup functions to work with new table structure


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-5e92917cdf20ae990148a5f35cc1e24c0a6e227f82f620b81a6b379854a0d083">+13/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Update views for new database schema and imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helpers/views.py

• Updated database queries to use <code>voice_channels</code> table with <code>is_active </code><br><code>= 1</code> filters<br> • Moved <code>fetch_channel_settings</code> import from voice_utils to <br>voice_settings module<br> • Applied consistent database query patterns for <br>channel lookups


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-567eeee56a343d3d37e38a764fd930ef30ed68464183d37040ec170bed6ca7d1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.py</strong><dd><code>Add new database schema for multiple voice channels support</code></dd></summary>
<hr>

services/db/schema.py

• Added new <code>voice_channels</code> table with support for multiple channels <br>per owner<br> • Created indexes for efficient querying on owner, active <br>status, and channel ID<br> • Added <code>user_jtc_preferences</code> table for <br>deterministic JTC channel selection<br> • Maintained backward <br>compatibility by keeping legacy <code>user_voice_channels</code> table


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-b5bbdcb671375f611b3921df790014200f2274223124b500ad943748d1a5d01f">+42/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>permissions_helper.py</strong><dd><code>Update permissions helper for new voice channels table</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helpers/permissions_helper.py

• Updated SELECT query to use <code>voice_channels</code> table with <code>is_active = 1</code> <br>filter<br> • Modified UPDATE statement to target <code>voice_channels</code> table with <br>active channel condition


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-7e4c38079f807cadcd1c77477a55836fe24ad0868d45e580361a8ac91b7937f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>migrate.py</strong><dd><code>Simplify database connection handling in migration script</code></dd></summary>
<hr>

scripts/migrate.py

• Refactored database connection context management using combined <br><code>async with</code> statement<br> • Simplified cursor handling by removing nested <br>context manager


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-885937e3dae34b828a5234ced7971ea5de2ddc0f806b3768f6b8b73d293dd630">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>009_multiple_channels_per_owner.sql</strong><dd><code>Add database migration for multiple channels per owner support</code></dd></summary>
<hr>

migrations/009_multiple_channels_per_owner.sql

• Added new database migration to support multiple channels per owner <br>per JTC<br> • Transforms voice_channels table with autoincrement ID and <br>new schema<br> • Includes data migration from old tables and proper <br>indexing


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-7bce07df519154ebd9d8a6380c159ef54656f35b791f4963f89a610a0aa43d98">+133/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_voice_cleanup.py</strong><dd><code>Update voice cleanup tests for new database schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_voice_cleanup.py

• Updated all database INSERT statements to use new <code>voice_channels</code> <br>table schema with additional fields<br> • Modified SELECT queries to <br>include <code>is_active = 1</code> filter for active channel checks<br> • Added <br>verification for <code>is_active</code> field updates after reconciliation <br>processes<br> • Updated test assertions to work with new database <br>structure


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-f00be2b461e11a30f993488df77a35dc099f4f647ce83aa229903870fb1c6ad2">+80/-71</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_voice_settings_integration.py</strong><dd><code>Enhance voice settings integration test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_voice_settings_integration.py

• Added comprehensive parametrized tests for channel creation with <br>various saved settings combinations<br> • Enhanced test coverage for empty <br>channel name fallback scenarios<br> • Replaced direct database mocking <br>with <code>mock_db_connection</code> fixture for consistency<br> • Added integration <br>test for complete voice command flow with fake Discord objects


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-4c1a4166a2c7573cd7719a4b9a656ab6ef1d012142f1de72049fc00b62c20894">+284/-103</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_voice_multiple_channels.py</strong><dd><code>Add tests for multiple channels per owner functionality</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/test_voice_multiple_channels.py

• Added comprehensive test suite for multiple channels per owner per <br>JTC functionality<br> • Tests verify that joining JTC always creates new <br>channels instead of redirecting to existing ones<br> • Validates <br>channel-specific cleanup operations and database record management<br> • <br>Ensures proper scoping and isolation between multiple user channels


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-4610e3a63a0e089102663f2a28841e09f73ac9d539a51ea1a07dfb4344fecc65">+307/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_voice_strict_scoping.py</strong><dd><code>Add tests for strict voice settings scoping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_voice_strict_scoping.py

• Added test suite to verify strict voice settings scoping per <br>guild/JTC/user combination<br> • Tests ensure no settings bleeding between <br>different JTC channels<br> • Validates that all voice permission and <br>feature functions use exact parameter matching<br> • Confirms error <br>handling and parameter validation requirements


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-f6f7eb01a4b8cd27e720e1ef7d870c6eb41323b40390b61283fb2688f6ce6b71">+275/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_rsi_live_probe.py</strong><dd><code>Enhance RSI live probe tests with integration markers</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_rsi_live_probe.py

• Added integration test markers and environment variable checks for <br>opt-in testing<br> • Refactored test methods into smaller helper functions <br>for better maintainability<br> • Enhanced probe result analysis and <br>summary reporting functionality<br> • Added fixture for automatic test <br>skipping when <code>RSI_LIVE=1</code> is not set


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-ae55133aeb91ed081b0b01ca7cb1b64989dfac7160ab48c7c99f65f3838b19a0">+71/-55</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_voice_settings_deterministic_simple.py</strong><dd><code>Add deterministic voice settings core functionality tests</code></dd></summary>
<hr>

tests/test_voice_settings_deterministic_simple.py

• Added focused tests for deterministic voice settings core database <br>functions<br> • Tests cover last used JTC channel tracking and preference <br>management<br> • Validates error handling and consistent behavior across <br>multiple calls<br> • Ensures proper scoping of preferences per guild/user <br>combination


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-4ed1c1f4bfb2c1a3decc1a9173739a2f330b01b599a8012eda70e5088cb36a98">+187/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Enhance test fixtures with database mocking utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

• Added <code>mock_db_connection</code> fixture for consistent database mocking <br>across tests<br> • Implemented helper methods for setting database query <br>results and validating calls<br> • Added <code>voice_service</code> fixture for <br>creating test VoiceService instances<br> • Enhanced test infrastructure <br>with better database mocking capabilities


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_voice_permissions.py</strong><dd><code>Update voice permissions tests for new query patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_voice_permissions.py

• Updated test assertions to expect new database query patterns with <br><code>voice_channels</code> table<br> • Added verification for <code>is_active = 1</code> filters <br>and <code>ORDER BY created_at DESC LIMIT 1</code> clauses<br> • Modified test <br>expectations to match enhanced query functionality


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-fa81959eecdbf7e7613e585fc56207b434e4ed9e9a721b86d158fb78b19561ff">+12/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_ownership_transfer_final.py</strong><dd><code>Update ownership transfer tests for new voice channels schema</code></dd></summary>
<hr>

tests/test_ownership_transfer_final.py

• Updated database table references from <code>user_voice_channels</code> to <br><code>voice_channels</code><br> • Added <code>is_active</code> column with value 1 in INSERT <br>statements<br> • Modified SELECT queries to use new table name and <br>structure


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-7608d3ca888ffbb4a00059aa96c1ae86fcb3c6ac55b2c811d88c805c9e523f1a">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_voice_owner_simple.py</strong><dd><code>Migrate voice owner tests to new database schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_voice_owner_simple.py

• Changed INSERT statements to use <code>voice_channels</code> table instead of <br><code>user_voice_channels</code><br> • Added <code>last_activity</code> and <code>is_active</code> columns to <br>database operations<br> • Updated DELETE statements to reference new table <br>structure


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-efeeef343a3296630506e33b8535d3edf5f4e8d90244e2fad37401f1ff471727">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_voice_owner_command.py</strong><dd><code>Update voice owner command tests for schema migration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_voice_owner_command.py

• Changed INSERT statement to use <code>voice_channels</code> table with additional <br>columns<br> • Added <code>last_activity</code> and <code>is_active</code> fields to test data <br>insertion


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-7488faeeb348e4de49ff709d1dc2928d907958f1d20320160f464bc1c91b96b2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_smoke.py</strong><dd><code>Add smoke test for basic import verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_smoke.py

• Added new smoke test file to verify basic imports and pytest wiring<br> <br>• Tests core module imports including ConfigLoader, ConfigService, and <br>VoiceService


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-da9ef240243bf38ab4e33d1f8a2a64caee7677dc780e58557f3c676687a4b334">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_voice_reconciliation.py</strong><dd><code>Update voice reconciliation test for soft deletion pattern</code></dd></summary>
<hr>

tests/test_voice_reconciliation.py

• Changed DELETE statement to UPDATE with <code>is_active = 0</code> for soft <br>deletion approach<br> • Updated database operation to mark channels as <br>inactive instead of hard deletion


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-aa8b6f97772184226ef9711754060dd2d0caf1369df2fa4d0ec7744d6a49544e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_voice_cleanup.py.backup</strong><dd><code>Add comprehensive voice cleanup functionality tests backup</code></dd></summary>
<hr>

tests/test_voice_cleanup.py.backup

• Added comprehensive backup test file for voice channel cleanup <br>functionality<br> • Includes tests for immediate cleanup, startup <br>reconciliation, and scheduled cleanup<br> • Tests various scenarios <br>including empty channels, active channels, and error handling


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-c19eba037163ee60ae2a3a83eb50ce9e836fe591b3da2e5bd721555e04c60d01">+596/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>rsi_probe.py</strong><dd><code>Minor code cleanup and formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/rsi_probe.py

• Minor code formatting improvements and unused variable cleanup<br> • <br>Simplified conditional logic in warmup execution<br> • Removed unused <br>variable assignments in report generation<br> • Applied consistent code <br>style formatting


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-127f6c0dbe1a62e5fd1f79c3076715206bac334723617a4ea37c47ee135a46ba">+13/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_admin_config_choices.py</strong><dd><code>Fix unused variable warnings in admin config tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_admin_config_choices.py

• Replaced unused variables with underscore prefix to follow Python <br>conventions<br> • Applied consistent variable naming for ignored return <br>values<br> • Minor code style improvements for better readability


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-d9d0ff093cb3b909335bbb3ede1035b47cf505bfcfd638cec795c5fc596a0620">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_services.py</strong><dd><code>Fix unused variable warning in services tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_services.py

• Fixed unused variable warning by prefixing with underscore<br> • Minor <br>code style improvement for better compliance


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-caee650c3003842e9277d696a063ab724d42606e64cbf44cf1deb9d1d67d1d98">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_is_valid_rsi_handle_moniker.py</strong><dd><code>Fix unused variable warning in RSI handle test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_is_valid_rsi_handle_moniker.py

• Replaced unused variable <code>cased_handle</code> with <code>_cased_handle</code> to indicate <br>it's intentionally unused


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-07dcafd3033fb410290e6a0fa111f0070175eca7a754a14fb69ba1e8566aef45">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database.py</strong><dd><code>Fix unused variable warning in database service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/db/database.py

• Replaced unused variable <code>cid</code> with <code>_cid</code> to suppress linting warnings


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-da8daca2decf28c9863d25bb73bc90dd8cd523dbc132244af22bfd29d93a2d0c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_username_404_flow.py</strong><dd><code>Fix unused variable warning in username 404 flow test</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_username_404_flow.py

• Replaced unused variable <code>message</code> with <code>_message</code> to indicate <br>intentional non-use


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-a01ece283378573e4e2fa3adfda8bd230c92d91949a53e8322626c7fe8f52d4a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>modals.py</strong><dd><code>Fix unused variable warning in modals helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helpers/modals.py

• Replaced unused variable <code>old_status</code> with <code>_old_status</code> to suppress <br>warnings


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-c1cb40e95e3801975f2eb6ce510b67047e385545722cde3e4ab0d8da7c561c11">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>recheck.py</strong><dd><code>Fix unused variable warnings in admin recheck cog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cogs/admin/recheck.py

• Replaced unused variables <code>old_status</code> and <code>new_status</code> with underscore <br>prefixes


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-cacaed138302d90ceef5a55884c7a479bfe3e186922dbc29ee07d9292c533948">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>fix_voice_tests.py</strong><dd><code>Add utility script for voice test schema migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fix_voice_tests.py

• Added utility script to automatically fix test files for new <br>voice_channels schema<br> • Implements regex-based replacements for INSERT <br>statements and parameter tuples<br> • Handles various parameter patterns <br>and edge cases in test data<br> • Provides automated migration assistance <br>for test file updates


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-26a45485c130b5d137719aefc008208874f1190b34cbde11ecfeab93cebee7c6">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fix_tests.sh</strong><dd><code>Add script to fix tests for new database schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fix_tests.sh

• Added shell script to fix test files for new database schema<br> • <br>Includes sed commands to update INSERT statements with proper column <br>structure


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-38678226f6d73c64483a3620ec19d25d9ba04b01495dccfb5626223f949b6052">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update project dependencies and pytest configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

• Added <code>requests</code> dependency to project requirements<br> • Updated pytest <br>configuration with coverage settings and integration test markers<br> • <br>Added coverage fail threshold and quiet mode options


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tests.yml</strong><dd><code>Enhance CI workflow with coverage and new dependencies</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/tests.yml

• Added <code>pytest-cov</code> and <code>requests</code> to CI dependencies<br> • Simplified test <br>execution to use pytest with coverage directly


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957f">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.json</strong><dd><code>Add VSCode pytest task configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/tasks.json

• Added VSCode task configuration for running pytest with quiet mode<br> • <br>Configured as default test task with shared panel presentation


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745a">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pytest.ini</strong><dd><code>Add integration test marker to pytest configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pytest.ini

• Added integration test marker configuration<br> • Enables selective test <br>execution with integration marker filtering


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Add requests dependency to requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

• Added `requests` library dependency with version constraints


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>requirements-dev.txt</strong><dd><code>Add pytest-cov to development dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements-dev.txt

• Added `pytest-cov` dependency for coverage reporting in development


</details>


  </td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_voice_ui_fix.py</strong></td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-f815a9a77712c0b8c8444ae52ed67eb009f7dcd85369ffcf18d5a63838d44630">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_voice_ui_simple.py</strong></td>
  <td><a href="https://github.com/Chromeninja/test_squadron_discord_bot/pull/122/files#diff-250f10a46b85ce4e6cac60fd3d52ea5bf249149ebc9db5efd71d487ea9bcc7a6">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

