### PR TITLE
Add role-revoke command for delegation policy enforcement

### DIFF
--- a/cogs/admin/role_delegation.py
+++ b/cogs/admin/role_delegation.py
@@ -124,9 +124,10 @@ class RoleDelegationCog(commands.Cog):
 
         Permission model: Access is controlled by delegation policies configured
         per-guild (roles.delegation_policies in config). Users must have a grantor
-        role defined in an applicable policy to revoke the target role. The revoker
-        must have permission to grant the role (same policy check as /role-grant),
-        and the target member must currently have the role.
+        role defined in an applicable policy for the target role. For revocation,
+        only the grantor-role requirement is enforced: prerequisite roles that
+        would be required to grant the role are not evaluated. The target member
+        must currently have the role.
         """
         await interaction.response.defer(ephemeral=True)
 


### PR DESCRIPTION
Implement a new command to revoke roles based on delegation policies, ensuring that only authorized members can perform the action. Introduce a method to check revocation permissions and update relevant tests.

## Summary by Sourcery

Add delegated role revocation support, including permission checks, logging, and a new admin slash command.

New Features:
- Introduce a /role-revoke admin command to remove roles under delegation policies.
- Add a delegation-aware apply_revoke workflow to remove roles from members based on configured grantor roles.

Enhancements:
- Add a can_revoke permission check that validates revocation authority independently of grant prerequisites.
- Log delegated role revocations to the leadership log with appropriate metadata and audit context.

Tests:
- Extend role delegation service tests to cover revocation success and failure cases, leadership logging, and reason strings.