### PR TITLE
feat(tickets): implement deleted ticket transcript posting to leadership channel

### DIFF
--- a/helpers/ticket_views.py
+++ b/helpers/ticket_views.py
@@ -22,10 +22,10 @@ AI Notes:
 from __future__ import annotations
 
 import io
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
-import discord  # type: ignore[import-not-found]
-from discord.ui import (  # type: ignore[import-not-found]
+import discord
+from discord.ui import (
     Button,
     Modal,
     Select,
@@ -34,6 +34,7 @@ from discord.ui import (  # type: ignore[import-not-found]
 )
 
 from helpers.embeds import EmbedColors, create_embed
+from helpers.leadership_log import resolve_leadership_channel
 from services.ticket_service import (
     DEFAULT_MAX_OPEN_PER_USER,
     DEFAULT_REOPEN_WINDOW_HOURS,
@@ -130,6 +131,48 @@ async def _log_ticket_event(
     except Exception as e:
         logger.exception(
             "Failed to log ticket event to channel in guild %s",
+            guild_id,
+            exc_info=e,
+        )
+
+
+async def _post_deleted_ticket_transcript(
+    bot: MyBot,
+    guild_id: int,
+    *,
+    thread: discord.Thread,
+    deleted_by: discord.abc.User,
+    ticket: dict[str, Any],
+    transcript_file: discord.File | None,
+) -> None:
+    """Post delete audit details to the leadership announcement channel."""
+    try:
+        leadership_channel = await resolve_leadership_channel(bot, guild_id)
+        if leadership_channel is None:
+            return
+
+        creator_id = ticket.get("user_id")
+        creator_line = (
+            f"<@{creator_id}>" if isinstance(creator_id, int) else "unknown"
+        )
+        embed = create_embed(
+            title="🗑️ Ticket Deleted",
+            description=(
+                f"**Thread:** `{thread.id}`\n"
+                f"**Deleted by:** {deleted_by.mention}\n"
+                f"**Creator:** {creator_line}"
+            ),
+            color=EmbedColors.WARNING,
+        )
+
+        if transcript_file is not None:
+            await leadership_channel.send(embed=embed, file=transcript_file)
+        else:
+            await leadership_channel.send(embed=embed)
+    except Exception as e:
+        logger.exception(
+            "Failed to post deleted ticket transcript for thread %s in guild %s",
+            thread.id,
             guild_id,
             exc_info=e,
         )
@@ -267,7 +310,7 @@ class TicketDescriptionModal(Modal, title="Describe Your Issue"):
     After submission the actual thread-creation flow continues.
     """
 
-    description_input = TextInput(
+    description_input: TextInput = TextInput(
         label="Description",
         style=discord.TextStyle.paragraph,
         placeholder="Please describe your issue or question…",
@@ -303,7 +346,7 @@ class TicketDescriptionModal(Modal, title="Describe Your Issue"):
 class TicketCloseReasonModal(Modal, title="Close Ticket"):
     """Modal for providing an optional reason when closing a ticket."""
 
-    reason_input = TextInput(
+    reason_input: TextInput = TextInput(
         label="Reason for closing",
         style=discord.TextStyle.paragraph,
         placeholder="Optional — why is this ticket being closed?",
@@ -354,15 +397,15 @@ class TicketPanelView(View):
         private_style = self._color_to_button_style(private_button_color, discord.ButtonStyle.primary)
         public_style = self._color_to_button_style(public_button_color, discord.ButtonStyle.secondary)
 
-        create_btn = Button(
+        create_btn: Button = Button(
             label=private_button_text,
             style=private_style,
             custom_id="ticket_create_button",
             emoji=private_button_emoji,
         )
-        create_btn.callback = self._on_create_private_ticket
+        cast("Any", create_btn).callback = self._on_create_private_ticket
 
-        public_btn = None
+        public_btn: Button | None = None
         if enable_public_button:
             public_btn = Button(
                 label=public_button_text,
@@ -370,7 +413,7 @@ class TicketPanelView(View):
                 custom_id="ticket_create_public_button",
                 emoji=public_button_emoji,
             )
-            public_btn.callback = self._on_create_public_ticket
+            cast("Any", public_btn).callback = self._on_create_public_ticket
 
         # Add buttons in the specified order
         if button_order == "public_first" and public_btn:
@@ -637,43 +680,43 @@ class TicketActionView(View):
         super().__init__(timeout=None)
         self.bot = bot
 
-        claim_btn = Button(
+        claim_btn: Button = Button(
             label="Claim",
             style=discord.ButtonStyle.secondary,
             custom_id="ticket_action_claim_button",
             emoji="🙋",
             disabled=ticket_is_closed,
         )
-        claim_btn.callback = self._on_claim_ticket
+        cast("Any", claim_btn).callback = self._on_claim_ticket
         self.add_item(claim_btn)
 
-        close_btn = Button(
+        close_btn: Button = Button(
             label="Close Ticket",
             style=discord.ButtonStyle.danger,
             custom_id="ticket_action_close_button",
             emoji="🔒",
             disabled=ticket_is_closed,
         )
-        close_btn.callback = self._on_close_ticket
+        cast("Any", close_btn).callback = self._on_close_ticket
         self.add_item(close_btn)
 
-        reopen_btn = Button(
+        reopen_btn: Button = Button(
             label="Reopen Ticket",
             style=discord.ButtonStyle.success,
             custom_id="ticket_action_reopen_button",
             emoji="🔓",
             disabled=(not ticket_is_closed) or (not reopen_enabled),
         )
-        reopen_btn.callback = self._on_reopen_ticket
+        cast("Any", reopen_btn).callback = self._on_reopen_ticket
         self.add_item(reopen_btn)
 
-        delete_btn = Button(
+        delete_btn: Button = Button(
             label="Delete Ticket",
             style=discord.ButtonStyle.danger,
             custom_id="ticket_action_delete_button",
             emoji="🗑️",
         )
-        delete_btn.callback = self._on_delete_ticket
+        cast("Any", delete_btn).callback = self._on_delete_ticket
         self.add_item(delete_btn)
 
     # -- Claim --
@@ -958,6 +1001,17 @@ class TicketActionView(View):
 
         await interaction.response.defer(ephemeral=True)
 
+        transcript_file: discord.File | None = None
+        try:
+            transcript_file = await _generate_transcript(thread)
+        except Exception as e:
+            logger.exception(
+                "Failed to generate transcript for deleted thread %s in guild %s",
+                thread.id,
+                guild_id,
+                exc_info=e,
+            )
+
         try:
             await thread.delete(
                 reason=(
@@ -991,6 +1045,15 @@ class TicketActionView(View):
 
         # Mark the ticket's thread as deleted in the DB for analytics
         await ticket_service.mark_thread_deleted(thread.id)
+
+        await _post_deleted_ticket_transcript(
+            self.bot,
+            guild_id,
+            thread=thread,
+            deleted_by=interaction.user,
+            ticket=ticket,
+            transcript_file=transcript_file,
+        )
 
         await _log_ticket_event(
             self.bot,

--- a/helpers/ticket_views.py
+++ b/helpers/ticket_views.py
@@ -169,12 +169,11 @@ async def _post_deleted_ticket_transcript(
             await leadership_channel.send(embed=embed, file=transcript_file)
         else:
             await leadership_channel.send(embed=embed)
-    except Exception as e:
+    except Exception:
         logger.exception(
             "Failed to post deleted ticket transcript for thread %s in guild %s",
             thread.id,
             guild_id,
-            exc_info=e,
         )
 
 

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 import sqlite3
 import time
-from typing import Any
+from typing import Any, cast
 
 from helpers.role_ids import normalize_role_id_list
 from services.base import BaseService
@@ -392,7 +392,8 @@ class TicketService(BaseService):
         result: list[int] = []
         for row in rows:
             try:
-                val = row["channel_id"] if isinstance(row, dict) else row[0]
+                row_data = cast("Any", row)
+                val = row_data["channel_id"]
                 result.append(int(val))
             except (TypeError, ValueError, KeyError, IndexError):
                 continue
@@ -918,7 +919,7 @@ class TicketService(BaseService):
         Returns:
             List of ticket dicts.
         """
-        where = "WHERE guild_id = ? AND status = 'open'"
+        where = "WHERE guild_id = ? AND status = 'open' AND deleted_at IS NULL"
         params: list[Any] = [guild_id]
         if user_id is not None:
             where += " AND user_id = ?"
@@ -992,8 +993,9 @@ class TicketService(BaseService):
         )
         counts: dict[str, int] = {"open": 0, "closed": 0}
         for row in rows:
-            status = row["status"] if isinstance(row, dict) else row[0]
-            cnt = row["cnt"] if isinstance(row, dict) else row[1]
+            row_data = cast("Any", row)
+            status = row_data["status"]
+            cnt = row_data["cnt"]
             if status in counts:
                 counts[status] = int(cnt)
         return {
@@ -1042,9 +1044,10 @@ class TicketService(BaseService):
             (guild_id,),
         )
         row = rows[0] if rows else None
-        active = int((row["active"] if isinstance(row, dict) else row[0]) or 0) if row else 0
-        archived = int((row["archived"] if isinstance(row, dict) else row[1]) or 0) if row else 0
-        deleted = int((row["deleted"] if isinstance(row, dict) else row[2]) or 0) if row else 0
+        row_data = cast("Any", row) if row is not None else None
+        active = int((row_data["active"] if row_data is not None else 0) or 0)
+        archived = int((row_data["archived"] if row_data is not None else 0) or 0)
+        deleted = int((row_data["deleted"] if row_data is not None else 0) or 0)
         total_threads = active + archived
         usage_pct = round((total_threads / thread_limit) * 100, 1) if thread_limit else 0
 
@@ -1334,22 +1337,18 @@ class TicketService(BaseService):
             so compatibility ALTER logic has a single source of truth.
             Uses double-checked locking to prevent concurrent runs.
         """
-        if self._category_schema_checked:
-            return
+        if not self._category_schema_checked:
+            async with self._schema_lock:
+                if not self._category_schema_checked:
+                    async with Database.get_connection() as db:
+                        try:
+                            await ensure_ticket_schema_compatibility(db)
+                            await db.commit()
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column name" not in str(e).lower():
+                                raise
 
-        async with self._schema_lock:
-            if self._category_schema_checked:
-                return
-
-            async with Database.get_connection() as db:
-                try:
-                    await ensure_ticket_schema_compatibility(db)
-                    await db.commit()
-                except sqlite3.OperationalError as e:
-                    if "duplicate column name" not in str(e).lower():
-                        raise
-
-            self._category_schema_checked = True
+                    self._category_schema_checked = True
 
     async def _ensure_ticket_schema_compatibility(self) -> None:
         """Ensure ``deleted_at`` column exists on older DBs.
@@ -1359,50 +1358,42 @@ class TicketService(BaseService):
             Only runs once per process lifetime.  Uses double-checked
             locking via ``_schema_lock``.
         """
-        if self._ticket_schema_checked:
-            return
+        if not self._ticket_schema_checked:
+            async with self._schema_lock:
+                if not self._ticket_schema_checked:
+                    rows = await BaseRepository.fetch_all("PRAGMA table_info(tickets)")
+                    column_names = {
+                        self.extract_column_name(row)
+                        for row in rows
+                        if self.extract_column_name(row)
+                    }
 
-        async with self._schema_lock:
-            if self._ticket_schema_checked:
-                return
+                    if "deleted_at" not in column_names:
+                        try:
+                            await BaseRepository.execute(
+                                "ALTER TABLE tickets "
+                                "ADD COLUMN deleted_at INTEGER DEFAULT NULL"
+                            )
+                            self.logger.info("Added missing deleted_at column to tickets")
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column name" not in str(e).lower():
+                                raise
 
-            rows = await BaseRepository.fetch_all("PRAGMA table_info(tickets)")
-            column_names = {
-                self.extract_column_name(row)
-                for row in rows
-                if self.extract_column_name(row)
-            }
-
-            if "deleted_at" not in column_names:
-                try:
-                    await BaseRepository.execute(
-                        "ALTER TABLE tickets "
-                        "ADD COLUMN deleted_at INTEGER DEFAULT NULL"
-                    )
-                    self.logger.info("Added missing deleted_at column to tickets")
-                except sqlite3.OperationalError as e:
-                    if "duplicate column name" not in str(e).lower():
-                        raise
-
-            self._ticket_schema_checked = True
+                    self._ticket_schema_checked = True
 
     async def _ensure_channel_config_schema_compatibility(self) -> None:
         """Ensure public button columns exist on older DBs."""
-        if self._channel_config_schema_checked:
-            return
-
-        async with self._schema_lock:
-            if self._channel_config_schema_checked:
-                return
-
-            rows = await BaseRepository.fetch_all(
-                "PRAGMA table_info(ticket_channel_configs)"
-            )
-            column_names = {
-                self.extract_column_name(row)
-                for row in rows
-                if self.extract_column_name(row)
-            }
+        if not self._channel_config_schema_checked:
+            async with self._schema_lock:
+                if not self._channel_config_schema_checked:
+                    rows = await BaseRepository.fetch_all(
+                        "PRAGMA table_info(ticket_channel_configs)"
+                    )
+                    column_names = {
+                        self.extract_column_name(row)
+                        for row in rows
+                        if self.extract_column_name(row)
+                    }
 
             if "enable_public_button" not in column_names:
                 try:
@@ -1633,6 +1624,7 @@ class TicketService(BaseService):
             """
             SELECT COUNT(*) FROM tickets
             WHERE guild_id = ? AND user_id = ? AND status = 'open'
+                AND deleted_at IS NULL
             """,
             (guild_id, user_id),
             default=0,

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -1395,86 +1395,86 @@ class TicketService(BaseService):
                         if self.extract_column_name(row)
                     }
 
-            if "enable_public_button" not in column_names:
-                try:
-                    await BaseRepository.execute(
-                        "ALTER TABLE ticket_channel_configs "
-                        "ADD COLUMN enable_public_button INTEGER NOT NULL DEFAULT 0"
-                    )
-                    self.logger.info(
-                        "Added missing enable_public_button column to ticket_channel_configs"
-                    )
-                except sqlite3.OperationalError as e:
-                    if "duplicate column name" not in str(e).lower():
-                        raise
+                    if "enable_public_button" not in column_names:
+                        try:
+                            await BaseRepository.execute(
+                                "ALTER TABLE ticket_channel_configs "
+                                "ADD COLUMN enable_public_button INTEGER NOT NULL DEFAULT 0"
+                            )
+                            self.logger.info(
+                                "Added missing enable_public_button column to ticket_channel_configs"
+                            )
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column name" not in str(e).lower():
+                                raise
 
-            if "public_button_text" not in column_names:
-                try:
-                    await BaseRepository.execute(
-                        "ALTER TABLE ticket_channel_configs "
-                        "ADD COLUMN public_button_text TEXT NOT NULL "
-                        "DEFAULT 'Create Public Ticket'"
-                    )
-                    self.logger.info(
-                        "Added missing public_button_text column to ticket_channel_configs"
-                    )
-                except sqlite3.OperationalError as e:
-                    if "duplicate column name" not in str(e).lower():
-                        raise
+                    if "public_button_text" not in column_names:
+                        try:
+                            await BaseRepository.execute(
+                                "ALTER TABLE ticket_channel_configs "
+                                "ADD COLUMN public_button_text TEXT NOT NULL "
+                                "DEFAULT 'Create Public Ticket'"
+                            )
+                            self.logger.info(
+                                "Added missing public_button_text column to ticket_channel_configs"
+                            )
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column name" not in str(e).lower():
+                                raise
 
-            if "public_button_emoji" not in column_names:
-                try:
-                    await BaseRepository.execute(
-                        "ALTER TABLE ticket_channel_configs "
-                        "ADD COLUMN public_button_emoji TEXT DEFAULT '\U0001f310'"
-                    )
-                    self.logger.info(
-                        "Added missing public_button_emoji column to ticket_channel_configs"
-                    )
-                except sqlite3.OperationalError as e:
-                    if "duplicate column name" not in str(e).lower():
-                        raise
+                    if "public_button_emoji" not in column_names:
+                        try:
+                            await BaseRepository.execute(
+                                "ALTER TABLE ticket_channel_configs "
+                                "ADD COLUMN public_button_emoji TEXT DEFAULT '\U0001f310'"
+                            )
+                            self.logger.info(
+                                "Added missing public_button_emoji column to ticket_channel_configs"
+                            )
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column name" not in str(e).lower():
+                                raise
 
-            if "private_button_color" not in column_names:
-                try:
-                    await BaseRepository.execute(
-                        "ALTER TABLE ticket_channel_configs "
-                        "ADD COLUMN private_button_color TEXT DEFAULT NULL"
-                    )
-                    self.logger.info(
-                        "Added missing private_button_color column to ticket_channel_configs"
-                    )
-                except sqlite3.OperationalError as e:
-                    if "duplicate column name" not in str(e).lower():
-                        raise
+                    if "private_button_color" not in column_names:
+                        try:
+                            await BaseRepository.execute(
+                                "ALTER TABLE ticket_channel_configs "
+                                "ADD COLUMN private_button_color TEXT DEFAULT NULL"
+                            )
+                            self.logger.info(
+                                "Added missing private_button_color column to ticket_channel_configs"
+                            )
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column name" not in str(e).lower():
+                                raise
 
-            if "public_button_color" not in column_names:
-                try:
-                    await BaseRepository.execute(
-                        "ALTER TABLE ticket_channel_configs "
-                        "ADD COLUMN public_button_color TEXT DEFAULT NULL"
-                    )
-                    self.logger.info(
-                        "Added missing public_button_color column to ticket_channel_configs"
-                    )
-                except sqlite3.OperationalError as e:
-                    if "duplicate column name" not in str(e).lower():
-                        raise
+                    if "public_button_color" not in column_names:
+                        try:
+                            await BaseRepository.execute(
+                                "ALTER TABLE ticket_channel_configs "
+                                "ADD COLUMN public_button_color TEXT DEFAULT NULL"
+                            )
+                            self.logger.info(
+                                "Added missing public_button_color column to ticket_channel_configs"
+                            )
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column name" not in str(e).lower():
+                                raise
 
-            if "button_order" not in column_names:
-                try:
-                    await BaseRepository.execute(
-                        "ALTER TABLE ticket_channel_configs "
-                        "ADD COLUMN button_order TEXT NOT NULL DEFAULT 'private_first'"
-                    )
-                    self.logger.info(
-                        "Added missing button_order column to ticket_channel_configs"
-                    )
-                except sqlite3.OperationalError as e:
-                    if "duplicate column name" not in str(e).lower():
-                        raise
+                    if "button_order" not in column_names:
+                        try:
+                            await BaseRepository.execute(
+                                "ALTER TABLE ticket_channel_configs "
+                                "ADD COLUMN button_order TEXT NOT NULL DEFAULT 'private_first'"
+                            )
+                            self.logger.info(
+                                "Added missing button_order column to ticket_channel_configs"
+                            )
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column name" not in str(e).lower():
+                                raise
 
-            self._channel_config_schema_checked = True
+                    self._channel_config_schema_checked = True
 
     # ------------------------------------------------------------------
     # Claim / Assign

--- a/tests/factories/discord_factories.py
+++ b/tests/factories/discord_factories.py
@@ -276,10 +276,16 @@ class FakeResponse:
         return self._is_done
 
     async def send_message(
-        self, content: str | None = None, ephemeral: bool = False, **kwargs: Any
+        self,
+        content: str | None = None,
+        embed: Any | None = None,
+        ephemeral: bool = False,
+        **kwargs: Any,
     ) -> None:
         self._is_done = True
-        self._messages.append({"content": content, "ephemeral": ephemeral, **kwargs})
+        self._messages.append(
+            {"content": content, "embed": embed, "ephemeral": ephemeral, **kwargs}
+        )
 
     async def defer(self, ephemeral: bool = False, thinking: bool = False) -> None:
         self._is_done = True
@@ -311,6 +317,10 @@ class FakeInteraction:
 
     # Explicit type annotation to allow None
     guild: FakeGuild | None
+    channel: Any | None
+    channel_id: int | None
+    response: Any
+    followup: Any
 
     def __init__(
         self,

--- a/tests/test_admin_status.py
+++ b/tests/test_admin_status.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
 
 from cogs.admin.commands import AdminCog
@@ -5,11 +8,14 @@ from tests.test_helpers import FakeInteraction, FakeUser
 
 
 @pytest.mark.asyncio
-async def test_admin_status_returns_expected_string(monkeypatch, mock_bot) -> None:
+async def test_admin_status_returns_expected_string(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_bot: Any,
+) -> None:
     # Mock the health service to return a simple status
-    mock_health = type("MockHealth", (), {})()
+    mock_health = SimpleNamespace()
 
-    async def mock_run_health_checks(bot, services):
+    async def mock_run_health_checks(bot: Any, services: Any) -> dict[str, Any]:
         return {
             "overall_status": "healthy",
             "services": {},
@@ -17,36 +23,49 @@ async def test_admin_status_returns_expected_string(monkeypatch, mock_bot) -> No
             "uptime": "1h",
         }
 
-    mock_health.run_health_checks = mock_run_health_checks  # type: ignore[attr-defined]
+    mock_health.run_health_checks = mock_run_health_checks
 
     # Mock service container to return our mock health service
-    mock_services = type("MockServices", (), {})()
-    mock_services.health = mock_health  # type: ignore[attr-defined]
-    mock_services.get_all_services = lambda: []  # type: ignore[attr-defined]
+    mock_services = SimpleNamespace()
+    mock_services.health = mock_health
+    mock_services.get_all_services = lambda: []
     mock_bot.services = mock_services
 
     # Mock admin permission check
-    async def mock_has_admin_permissions(user, guild=None):
+    async def mock_has_admin_permissions(
+        user: Any,
+        guild: Any = None,
+    ) -> bool:
         return True
 
     mock_bot.has_admin_permissions = mock_has_admin_permissions
 
     # Capture response - need to handle both send_message and followup
-    captured = {}
+    captured_content: str | None = None
+    captured_ephemeral = False
+    captured_embed: Any | None = None
 
-    async def capture_response(content=None, embed=None, ephemeral=False, **kwargs):
-        captured["content"] = str(embed.description) if embed else content
-        captured["ephemeral"] = ephemeral
-        captured["embed"] = embed
+    async def capture_response(
+        content: str | None = None,
+        embed: Any | None = None,
+        ephemeral: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        nonlocal captured_content, captured_ephemeral, captured_embed
+        captured_content = str(embed.description) if embed is not None else content
+        captured_ephemeral = ephemeral
+        captured_embed = embed
 
     # Build cog and run
     cog = AdminCog(mock_bot)
     ix = FakeInteraction(FakeUser(10, "AdminUser"))
-    ix.response.send_message = capture_response
-    ix.followup.send = capture_response
+    response: Any = ix.response
+    followup: Any = ix.followup
+    response.send_message = capture_response
+    followup.send = capture_response
 
     # Call the status command directly
     await cog.status.callback(cog, ix)  # type: ignore[arg-type]
 
     # Check that some status content was returned (could be in embed or content)
-    assert captured.get("embed") is not None or captured.get("content") is not None
+    assert captured_embed is not None or captured_content is not None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,7 +10,11 @@ from typing import Any
 
 from tests.factories.discord_factories import (
     FakeFollowup as _FactoryFakeFollowup,
+)
+from tests.factories.discord_factories import (
     FakeResponse as _FactoryFakeResponse,
+)
+from tests.factories.discord_factories import (
     FakeUser as _FactoryFakeUser,
 )
 
@@ -34,17 +38,28 @@ class FakeResponse(_FactoryFakeResponse):
 class FakeFollowup(_FactoryFakeFollowup):
     """Re-export the shared fake followup implementation."""
 
-    async def send(self, *args: Any, **kwargs: Any) -> None:
-        await super().send(*args, **kwargs)
+    async def send(
+        self,
+        content: str | None = None,
+        ephemeral: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        return await super().send(content=content, ephemeral=ephemeral, **kwargs)
 
 
 class FakeInteraction:
     """Backward-compatible minimal interaction wrapper for legacy tests."""
 
+    guild: SimpleNamespace | None
+    channel: Any | None
+    channel_id: int | None
+    response: Any
+    followup: Any
+
     def __init__(self, user: FakeUser | None = None) -> None:
         self.user = user or FakeUser()
-        self.response = FakeResponse()
-        self.followup = FakeFollowup()
+        self.response: Any = FakeResponse()
+        self.followup: Any = FakeFollowup()
         self.guild = SimpleNamespace(id=123, name="TestGuild")
         self.channel = None
         self.channel_id = None

--- a/tests/test_ticket_service.py
+++ b/tests/test_ticket_service.py
@@ -654,6 +654,21 @@ class TestMaxOpenTickets:
         assert count == 2
 
     @pytest.mark.asyncio
+    async def test_get_open_ticket_count_excludes_deleted(
+        self, ticket_svc: TicketService
+    ) -> None:
+        """Deleted ticket threads do not count as open tickets."""
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 21011, USER_ID)
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 21012, USER_ID)
+
+        deleted = await ticket_svc.mark_thread_deleted(21011)
+
+        count = await ticket_svc.get_open_ticket_count(GUILD_ID, USER_ID)
+
+        assert deleted is True
+        assert count == 1
+
+    @pytest.mark.asyncio
     async def test_check_max_open_tickets_under_limit(self, ticket_svc: TicketService) -> None:
         """User under the limit can open another ticket."""
         await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 22001, USER_ID)
@@ -673,6 +688,26 @@ class TestMaxOpenTickets:
         for i in range(DEFAULT_MAX_OPEN_PER_USER):
             await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 24000 + i, USER_ID)
         assert await ticket_svc.check_max_open_tickets(GUILD_ID, USER_ID) is False
+
+    @pytest.mark.asyncio
+    async def test_check_max_open_tickets_ignores_deleted_threads(
+        self, ticket_svc: TicketService
+    ) -> None:
+        """A deleted thread no longer blocks creating another ticket."""
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 24010, USER_ID)
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 24011, USER_ID)
+
+        blocked_before = await ticket_svc.check_max_open_tickets(
+            GUILD_ID, USER_ID, max_open=2
+        )
+        deleted = await ticket_svc.mark_thread_deleted(24010)
+        allowed_after = await ticket_svc.check_max_open_tickets(
+            GUILD_ID, USER_ID, max_open=2
+        )
+
+        assert blocked_before is False
+        assert deleted is True
+        assert allowed_after is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ticket_views.py
+++ b/tests/test_ticket_views.py
@@ -23,6 +23,7 @@ from helpers.ticket_views import (
     _close_ticket,
     _create_ticket_thread,
     _log_ticket_event,
+    _post_deleted_ticket_transcript,
 )
 from tests.conftest import FakeInteraction, FakeUser
 
@@ -593,10 +594,14 @@ class TestCreateTicketThread:
         interaction = FakeInteraction(user=FakeUser(user_id=42, display_name="Pilot"))
         role_category = SimpleNamespace(id=777, mention="@cat-role")
         role_global = SimpleNamespace(id=888, mention="@global-role")
+
+        def _get_role(rid: int) -> Any | None:
+            return {777: role_category, 888: role_global}.get(rid)
+
         guild = SimpleNamespace(
             id=123,
             name="TestGuild",
-            get_role=lambda rid: {777: role_category, 888: role_global}.get(rid),
+            get_role=_get_role,
         )
         interaction.guild = guild
 
@@ -913,12 +918,151 @@ class TestTicketDeleteButton:
         thread.delete = AsyncMock()
         interaction.channel = thread
 
-        with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
-            await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+        with patch(
+            "helpers.ticket_views._generate_transcript",
+            new=AsyncMock(return_value=None),
+        ):
+            with patch(
+                "helpers.ticket_views._post_deleted_ticket_transcript",
+                new=AsyncMock(),
+            ):
+                with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
+                    await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
 
         thread.delete.assert_awaited_once()
         bot.services.ticket.mark_thread_deleted.assert_awaited_once_with(55555)
         followup_send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_ticket_posts_transcript_to_leadership(self) -> None:
+        """Deleting a ticket posts the transcript to leadership when available."""
+        ticket = {"id": 1, "user_id": 42, "guild_id": 123}
+        bot = _mock_bot_with_services(ticket=ticket, staff_roles="[]")
+        view = TicketActionView(bot)
+
+        user = MagicMock(spec=discord.Member)
+        user.id = 42
+        user.roles = []
+        user.mention = "@creator"
+        user.guild_permissions = MagicMock()
+        user.guild_permissions.administrator = False
+
+        interaction = FakeInteraction(user=user)
+        interaction.followup.send = AsyncMock()
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 55555
+        thread.delete = AsyncMock()
+        interaction.channel = thread
+
+        transcript = MagicMock(spec=discord.File)
+
+        with patch(
+            "helpers.ticket_views._generate_transcript",
+            new=AsyncMock(return_value=transcript),
+        ):
+            with patch(
+                "helpers.ticket_views._post_deleted_ticket_transcript",
+                new=AsyncMock(),
+            ) as leadership_post:
+                with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
+                    await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+
+        leadership_post.assert_awaited_once()
+        assert leadership_post.await_args is not None
+        kwargs = leadership_post.await_args.kwargs
+        assert kwargs["thread"] is thread
+        assert kwargs["deleted_by"] is user
+        assert kwargs["ticket"] == ticket
+        assert kwargs["transcript_file"] is transcript
+
+    @pytest.mark.asyncio
+    async def test_delete_ticket_continues_without_transcript(self) -> None:
+        """Delete still succeeds if transcript generation fails."""
+        ticket = {"id": 1, "user_id": 42, "guild_id": 123}
+        bot = _mock_bot_with_services(ticket=ticket, staff_roles="[]")
+        view = TicketActionView(bot)
+
+        user = MagicMock(spec=discord.Member)
+        user.id = 42
+        user.roles = []
+        user.mention = "@creator"
+        user.guild_permissions = MagicMock()
+        user.guild_permissions.administrator = False
+
+        interaction = FakeInteraction(user=user)
+        interaction.followup.send = AsyncMock()
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 55555
+        thread.delete = AsyncMock()
+        interaction.channel = thread
+
+        with patch(
+            "helpers.ticket_views._generate_transcript",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            with patch(
+                "helpers.ticket_views._post_deleted_ticket_transcript",
+                new=AsyncMock(),
+            ) as leadership_post:
+                with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
+                    await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+
+        thread.delete.assert_awaited_once()
+        bot.services.ticket.mark_thread_deleted.assert_awaited_once_with(55555)
+        leadership_post.assert_awaited_once()
+        assert leadership_post.await_args is not None
+        assert leadership_post.await_args.kwargs["transcript_file"] is None
+
+    @pytest.mark.asyncio
+    async def test_post_deleted_ticket_transcript_without_channel(self) -> None:
+        """Leadership posting is skipped when no leadership channel is configured."""
+        bot = _mock_bot_with_services()
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 55555
+        user = MagicMock(spec=discord.Member)
+        user.mention = "@deleter"
+
+        with patch(
+            "helpers.ticket_views.resolve_leadership_channel",
+            new=AsyncMock(return_value=None),
+        ):
+            await _post_deleted_ticket_transcript(
+                bot,
+                123,
+                thread=thread,
+                deleted_by=user,
+                ticket={"user_id": 42},
+                transcript_file=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_post_deleted_ticket_transcript_sends_embed_and_file(self) -> None:
+        """Leadership posting includes the transcript attachment when present."""
+        bot = _mock_bot_with_services()
+        channel = AsyncMock(spec=discord.TextChannel)
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 55555
+        user = MagicMock(spec=discord.Member)
+        user.mention = "@deleter"
+        transcript = MagicMock(spec=discord.File)
+
+        with patch(
+            "helpers.ticket_views.resolve_leadership_channel",
+            new=AsyncMock(return_value=channel),
+        ):
+            await _post_deleted_ticket_transcript(
+                bot,
+                123,
+                thread=thread,
+                deleted_by=user,
+                ticket={"user_id": 42},
+                transcript_file=transcript,
+            )
+
+        channel.send.assert_awaited_once()
+        kwargs = channel.send.await_args.kwargs
+        assert kwargs["file"] is transcript
+        assert kwargs["embed"].title == "🗑️ Ticket Deleted"
 
     @pytest.mark.asyncio
     async def test_delete_ticket_forbidden_reports_error(self) -> None:

--- a/tests/test_views_verification.py
+++ b/tests/test_views_verification.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -8,7 +9,8 @@ from tests.test_helpers import FakeInteraction, FakeUser
 
 @pytest.mark.asyncio
 async def test_get_token_button_calls_rate_limit_and_sends_embed(
-    monkeypatch, mock_bot
+    monkeypatch: pytest.MonkeyPatch,
+    mock_bot: Any,
 ) -> None:
     view = VerificationView(mock_bot)
 
@@ -23,19 +25,26 @@ async def test_get_token_button_calls_rate_limit_and_sends_embed(
     defer_called = False
     followup_called = False
 
-    async def fake_defer(ephemeral=False):
+    async def fake_defer(ephemeral: bool = False, thinking: bool = False) -> None:
         nonlocal defer_called
         defer_called = True
         assert ephemeral is True
 
-    async def fake_followup_send(content, ephemeral=False, embed=None, **kwargs):
+    async def fake_followup_send(
+        content: str | None = None,
+        ephemeral: bool = False,
+        embed: Any | None = None,
+        **kwargs: Any,
+    ) -> None:
         nonlocal followup_called
         followup_called = True
         assert ephemeral is True
         assert embed is not None
 
-    ix.response.defer = fake_defer
-    ix.followup.send = fake_followup_send
+    response: Any = ix.response
+    followup: Any = ix.followup
+    response.defer = fake_defer
+    followup.send = fake_followup_send
 
     await view.get_token_button_callback(ix)  # type: ignore[arg-type]
     assert defer_called is True
@@ -44,7 +53,8 @@ async def test_get_token_button_calls_rate_limit_and_sends_embed(
 
 @pytest.mark.asyncio
 async def test_verify_button_opens_modal_when_not_rate_limited(
-    monkeypatch, mock_bot
+    monkeypatch: pytest.MonkeyPatch,
+    mock_bot: Any,
 ) -> None:
     view = VerificationView(mock_bot)
     # No longer need to patch check_rate_limit - it's been removed from button callback
@@ -56,7 +66,10 @@ async def test_verify_button_opens_modal_when_not_rate_limited(
 
 
 @pytest.mark.asyncio
-async def test_recheck_button_forwards_to_cog(monkeypatch, mock_bot) -> None:
+async def test_recheck_button_forwards_to_cog(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_bot: Any,
+) -> None:
     view = VerificationView(mock_bot)
 
     # Attach a fake VerificationCog with method recheck_button
@@ -64,7 +77,7 @@ async def test_recheck_button_forwards_to_cog(monkeypatch, mock_bot) -> None:
         def __init__(self) -> None:
             self.called = False
 
-        async def recheck_button(self, interaction) -> None:
+        async def recheck_button(self, interaction: Any) -> None:
             self.called = True
 
     fake_cog = FakeCog()

--- a/verification/rsi_verification.py
+++ b/verification/rsi_verification.py
@@ -1,8 +1,9 @@
 import logging
 import re
 import string
+from typing import TypedDict
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from helpers.circuit_breaker import get_rsi_circuit_breaker
 from helpers.http_helper import ForbiddenError, HTTPClient, NotFoundError
@@ -10,8 +11,20 @@ from helpers.http_helper import ForbiddenError, HTTPClient, NotFoundError
 RSI_HANDLE_REGEX = re.compile(r"^[A-Za-z0-9\[\]][A-Za-z0-9_\-\s\[\]]{0,59}$")
 logger = logging.getLogger(__name__)
 
+class OrgSelectors(TypedDict):
+    main: list[str]
+    affiliates: list[str]
+    main_sid: list[str]
+    affiliate_sid: list[str]
+
+
+class SelectorRegistry(TypedDict):
+    org: OrgSelectors
+    bio: list[str]
+
+
 # Selector registry for extensibility
-SELECTORS = {
+SELECTORS: SelectorRegistry = {
     "org": {
         "main": [
             'div[class*="org"][class*="main"] a.value',
@@ -194,9 +207,18 @@ def extract_handle(html_content: str | BeautifulSoup) -> str | None:
         handle_paragraph := soup.find(
             "p",
             class_="entry",
-            string=lambda text: text and "Handle name" in text,  # type: ignore[arg-type]
+            string=lambda text: isinstance(text, str) and "Handle name" in text,
         )
-    ) and (handle_strong := handle_paragraph.find("strong", class_="value")):
+    ):
+        if not isinstance(handle_paragraph, Tag):
+            logger.warning("Handle paragraph was not a Tag instance.")
+            return None
+
+        handle_strong = handle_paragraph.find("strong", class_="value")
+        if not isinstance(handle_strong, Tag):
+            logger.warning("Handle strong tag was not found or invalid.")
+            return None
+
         cased_handle = handle_strong.get_text(strip=True)
         logger.debug(f"Extracted cased handle: {cased_handle}")
         return cased_handle

--- a/web/backend/core/rsi_utils.py
+++ b/web/backend/core/rsi_utils.py
@@ -253,6 +253,14 @@ def _parse_org_name_from_html(
             )
 
         # Extract org name using different strategies
+        if not isinstance(h1_tag, Tag):
+            logger.warning(f"Unexpected <h1> node type in org page for {sid}")
+            return (
+                False,
+                None,
+                "Failed to parse organization page. The page structure may have changed.",
+            )
+
         org_name = _extract_org_name(h1_tag)
 
         if not org_name:

--- a/web/backend/core/schemas.py
+++ b/web/backend/core/schemas.py
@@ -1005,6 +1005,10 @@ class TicketInfo(BaseModel):
     channel_id: str
     thread_id: str
     user_id: str
+    creator_username: str | None = None
+    creator_global_name: str | None = None
+    creator_discriminator: str | None = None
+    creator_avatar_url: str | None = None
     category_id: int | None = None
     status: str = "open"
     closed_by: str | None = None

--- a/web/backend/routes/tickets.py
+++ b/web/backend/routes/tickets.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from core.dependencies import (
     InternalAPIClient,
@@ -457,14 +457,22 @@ async def list_tickets(
     """List tickets for the active guild with optional status filter."""
     guild_id = ensure_active_guild(current_user)
 
+    def _parse_ticket_user_id(raw_user_id: Any) -> int | None:
+        if raw_user_id is None:
+            return None
+        try:
+            return int(raw_user_id)
+        except (TypeError, ValueError):
+            return None
+
     offset = (page - 1) * page_size
     tickets = await svc.get_tickets(guild_id, status=status, limit=page_size, offset=offset)
     total = await svc.get_ticket_count(guild_id, status=status)
 
     creator_user_ids: set[int] = {
-        int(ticket["user_id"])
+        parsed_user_id
         for ticket in tickets
-        if ticket.get("user_id") is not None
+        if (parsed_user_id := _parse_ticket_user_id(ticket.get("user_id"))) is not None
     }
     creator_map = await _resolve_ticket_creators(
         internal_api,
@@ -472,39 +480,39 @@ async def list_tickets(
         creator_user_ids,
     )
 
-    items = [
-        TicketInfo(
-            id=t["id"],
-            guild_id=str(t["guild_id"]),
-            channel_id=str(t["channel_id"]),
-            thread_id=str(t["thread_id"]),
-            user_id=str(t["user_id"]),
-            creator_username=creator_map.get(int(t["user_id"]), {}).get(
-                "creator_username"
-            ),
-            creator_global_name=creator_map.get(int(t["user_id"]), {}).get(
-                "creator_global_name"
-            ),
-            creator_discriminator=creator_map.get(int(t["user_id"]), {}).get(
-                "creator_discriminator"
-            ),
-            creator_avatar_url=creator_map.get(int(t["user_id"]), {}).get(
-                "creator_avatar_url"
-            ),
-            category_id=t.get("category_id"),
-            status=t["status"],
-            closed_by=str(t["closed_by"]) if t.get("closed_by") else None,
-            created_at=t.get("created_at", 0),
-            closed_at=t.get("closed_at"),
-            claimed_by=str(t["claimed_by"]) if t.get("claimed_by") else None,
-            claimed_at=t.get("claimed_at"),
-            close_reason=t.get("close_reason"),
-            initial_description=t.get("initial_description"),
-            reopened_at=t.get("reopened_at"),
-            reopened_by=str(t["reopened_by"]) if t.get("reopened_by") else None,
+    items: list[TicketInfo] = []
+    for t in tickets:
+        creator_user_id = _parse_ticket_user_id(t.get("user_id"))
+        creator_data = (
+            creator_map.get(creator_user_id, {})
+            if creator_user_id is not None
+            else {}
         )
-        for t in tickets
-    ]
+
+        items.append(
+            TicketInfo(
+                id=t["id"],
+                guild_id=str(t["guild_id"]),
+                channel_id=str(t["channel_id"]),
+                thread_id=str(t["thread_id"]),
+                user_id=str(t["user_id"]),
+                creator_username=creator_data.get("creator_username"),
+                creator_global_name=creator_data.get("creator_global_name"),
+                creator_discriminator=creator_data.get("creator_discriminator"),
+                creator_avatar_url=creator_data.get("creator_avatar_url"),
+                category_id=t.get("category_id"),
+                status=t["status"],
+                closed_by=str(t["closed_by"]) if t.get("closed_by") else None,
+                created_at=t.get("created_at", 0),
+                closed_at=t.get("closed_at"),
+                claimed_by=str(t["claimed_by"]) if t.get("claimed_by") else None,
+                claimed_at=t.get("claimed_at"),
+                close_reason=t.get("close_reason"),
+                initial_description=t.get("initial_description"),
+                reopened_at=t.get("reopened_at"),
+                reopened_by=str(t["reopened_by"]) if t.get("reopened_by") else None,
+            )
+        )
     return TicketListResponse(
         items=items, total=total, page=page, page_size=page_size
     )

--- a/web/backend/routes/tickets.py
+++ b/web/backend/routes/tickets.py
@@ -7,6 +7,7 @@ guild-level ticket settings — all scoped to the active guild.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING
 
@@ -42,6 +43,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from helpers.role_ids import normalize_role_id_list
 from utils.logging import get_logger
 from web.backend.routes._ticket_helpers import require_guild_category
+from web.backend.routes.users import _get_member_with_cache
 
 if TYPE_CHECKING:
     from services.config_service import ConfigService
@@ -50,6 +52,61 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 router = APIRouter()
+
+
+async def _resolve_ticket_creators(
+    internal_api: InternalAPIClient,
+    guild_id: int,
+    user_ids: set[int],
+) -> dict[int, dict[str, str | None]]:
+    """Resolve creator identity data for a set of Discord user IDs.
+
+    Uses the shared member cache lookup from users routes so tickets follow
+    the same resolution behavior as other dashboard pages.
+    """
+    if not user_ids:
+        return {}
+
+    async def _resolve_one(user_id: int) -> tuple[int, dict[str, str | None]]:
+        try:
+            member_data = await _get_member_with_cache(internal_api, guild_id, user_id)
+        except Exception as exc:
+            logger.debug(
+                "Failed to resolve ticket creator for guild %s user %s",
+                guild_id,
+                user_id,
+                exc_info=exc,
+            )
+            return (
+                user_id,
+                {
+                    "creator_username": None,
+                    "creator_global_name": None,
+                    "creator_discriminator": None,
+                    "creator_avatar_url": None,
+                },
+            )
+
+        username = member_data.get("username")
+        global_name = member_data.get("global_name")
+        discriminator = member_data.get("discriminator")
+        avatar_url = member_data.get("avatar_url")
+        return (
+            user_id,
+            {
+                "creator_username": str(username) if username else None,
+                "creator_global_name": str(global_name) if global_name else None,
+                "creator_discriminator": (
+                    str(discriminator) if discriminator else None
+                ),
+                "creator_avatar_url": str(avatar_url) if avatar_url else None,
+            },
+        )
+
+    resolved_pairs = await asyncio.gather(
+        *(_resolve_one(user_id) for user_id in user_ids)
+    )
+    return dict(resolved_pairs)
 
 
 def _parse_role_id_list(field_name: str, raw_role_ids: list[str]) -> list[int]:
@@ -395,6 +452,7 @@ async def list_tickets(
     page_size: int = Query(20, ge=1, le=100),
     current_user: UserProfile = Depends(require_staff()),
     svc: TicketService = Depends(get_ticket_service),
+    internal_api: InternalAPIClient = Depends(get_internal_api_client),
 ) -> TicketListResponse:
     """List tickets for the active guild with optional status filter."""
     guild_id = ensure_active_guild(current_user)
@@ -403,6 +461,17 @@ async def list_tickets(
     tickets = await svc.get_tickets(guild_id, status=status, limit=page_size, offset=offset)
     total = await svc.get_ticket_count(guild_id, status=status)
 
+    creator_user_ids: set[int] = {
+        int(ticket["user_id"])
+        for ticket in tickets
+        if ticket.get("user_id") is not None
+    }
+    creator_map = await _resolve_ticket_creators(
+        internal_api,
+        guild_id,
+        creator_user_ids,
+    )
+
     items = [
         TicketInfo(
             id=t["id"],
@@ -410,6 +479,18 @@ async def list_tickets(
             channel_id=str(t["channel_id"]),
             thread_id=str(t["thread_id"]),
             user_id=str(t["user_id"]),
+            creator_username=creator_map.get(int(t["user_id"]), {}).get(
+                "creator_username"
+            ),
+            creator_global_name=creator_map.get(int(t["user_id"]), {}).get(
+                "creator_global_name"
+            ),
+            creator_discriminator=creator_map.get(int(t["user_id"]), {}).get(
+                "creator_discriminator"
+            ),
+            creator_avatar_url=creator_map.get(int(t["user_id"]), {}).get(
+                "creator_avatar_url"
+            ),
             category_id=t.get("category_id"),
             status=t["status"],
             closed_by=str(t["closed_by"]) if t.get("closed_by") else None,

--- a/web/frontend/src/api/endpoints.ts
+++ b/web/frontend/src/api/endpoints.ts
@@ -1169,6 +1169,10 @@ export interface TicketInfo {
   channel_id: string;
   thread_id: string;
   user_id: string;
+  creator_username?: string | null;
+  creator_global_name?: string | null;
+  creator_discriminator?: string | null;
+  creator_avatar_url?: string | null;
   category_id: number | null;
   status: string;
   closed_by: string | null;
@@ -1183,6 +1187,8 @@ export interface TicketSettings {
   close_message: string | null;
   staff_roles: string[];
   default_welcome_message: string | null;
+  max_open_per_user: number;
+  reopen_window_hours: number;
 }
 
 export interface TicketSettingsUpdate {
@@ -1191,6 +1197,8 @@ export interface TicketSettingsUpdate {
   close_message?: string | null;
   staff_roles?: string[];
   default_welcome_message?: string | null;
+  max_open_per_user?: number | null;
+  reopen_window_hours?: number | null;
 }
 
 export interface TicketChannelConfig {

--- a/web/frontend/src/components/BulkRecheckIntegrationExample.tsx
+++ b/web/frontend/src/components/BulkRecheckIntegrationExample.tsx
@@ -1,19 +1,19 @@
 /**
  * Example Integration: Using BulkRecheckResultsModal
- * 
+ *
  * This shows how to integrate the bulk recheck results modal into
  * your admin users page. Add this code to your existing admin page.
  */
 
 import { useState } from 'react';
 import { BulkRecheckResultsModal } from './BulkRecheckResultsModal';
-import { apiClient } from '../api/client';
+import { adminApi, type BulkRecheckResponse } from '../api/endpoints';
 import { handleApiError, showError } from '../utils/toast';
 
 // Example: In your AdminUsersPage component
 export function AdminUsersPageExample() {
   const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
-  const [recheckResults, setRecheckResults] = useState(null);
+  const [recheckResults, setRecheckResults] = useState<BulkRecheckResponse | null>(null);
   const [showResultsModal, setShowResultsModal] = useState(false);
   const [isRechecking, setIsRechecking] = useState(false);
 
@@ -26,13 +26,10 @@ export function AdminUsersPageExample() {
     setIsRechecking(true);
 
     try {
-      // Call the bulk recheck endpoint
-      const response = await apiClient.post('/api/admin/users/bulk-recheck', {
-        user_ids: selectedUsers,
-      });
+      const response = await adminApi.bulkRecheckUsers(selectedUsers);
 
       // Store results and show modal
-      setRecheckResults(response.data);
+      setRecheckResults(response);
       setShowResultsModal(true);
 
       // Optionally refresh the user list
@@ -50,7 +47,7 @@ export function AdminUsersPageExample() {
       {/* Your existing users list UI */}
       <div className="p-4">
         <h1>Admin Users Management</h1>
-        
+
         {/* Example user selection and bulk recheck button */}
         <div className="flex justify-between items-center mb-4">
           <div className="text-sm text-muted-foreground">
@@ -90,16 +87,14 @@ export function AdminUsersPageExample() {
  * Alternative: Trigger from a context menu or action button
  */
 export function UserRowWithRecheckExample({ userId }: { userId: string }) {
-  const [recheckResults, setRecheckResults] = useState(null);
+  const [recheckResults, setRecheckResults] = useState<BulkRecheckResponse | null>(null);
   const [showResultsModal, setShowResultsModal] = useState(false);
 
   const handleSingleRecheck = async () => {
     try {
-      const response = await apiClient.post('/api/admin/users/bulk-recheck', {
-        user_ids: [userId],
-      });
+      const response = await adminApi.bulkRecheckUsers([userId]);
 
-      setRecheckResults(response.data);
+      setRecheckResults(response);
       setShowResultsModal(true);
     } catch (error) {
       handleApiError(error, 'Failed to recheck user. Please try again.');

--- a/web/frontend/src/hooks/useGameMetrics.test.tsx
+++ b/web/frontend/src/hooks/useGameMetrics.test.tsx
@@ -89,7 +89,10 @@ describe('useGameMetrics', () => {
           enabled,
         }),
       {
-        initialProps: { gameName: 'Star Citizen', enabled: true },
+        initialProps: {
+          gameName: 'Star Citizen' as string | null,
+          enabled: true,
+        },
       },
     );
 

--- a/web/frontend/src/hooks/useUserMetrics.test.tsx
+++ b/web/frontend/src/hooks/useUserMetrics.test.tsx
@@ -80,7 +80,10 @@ describe('useUserMetrics', () => {
           enabled,
         }),
       {
-        initialProps: { userId: '123', enabled: true },
+        initialProps: {
+          userId: '123' as string | null,
+          enabled: true,
+        },
       },
     );
 

--- a/web/frontend/src/pages/Tickets.tsx
+++ b/web/frontend/src/pages/Tickets.tsx
@@ -78,6 +78,8 @@ export default function Tickets({ guildId }: TicketsProps) {
   const [closeMessage, setCloseMessage] = useState('');
   const [staffRoles, setStaffRoles] = useState<string[]>([]);
   const [defaultWelcomeMessage, setDefaultWelcomeMessage] = useState('');
+  const [maxOpenPerUser, setMaxOpenPerUser] = useState(5);
+  const [reopenWindowHours, setReopenWindowHours] = useState(48);
   const [saving, setSaving] = useState(false);
   const [deploying, setDeploying] = useState(false);
 
@@ -186,6 +188,8 @@ export default function Tickets({ guildId }: TicketsProps) {
       setCloseMessage(s.close_message ?? '');
       setStaffRoles(s.staff_roles);
       setDefaultWelcomeMessage(s.default_welcome_message ?? '');
+      setMaxOpenPerUser(s.max_open_per_user ?? 5);
+      setReopenWindowHours(s.reopen_window_hours ?? 48);
       setCategories(catsRes.categories);
       setStatsOpen(statsRes.open);
       setStatsClosed(statsRes.closed);
@@ -243,6 +247,8 @@ export default function Tickets({ guildId }: TicketsProps) {
         close_message: closeMessage || null,
         staff_roles: staffRoles,
         default_welcome_message: defaultWelcomeMessage || null,
+        max_open_per_user: maxOpenPerUser,
+        reopen_window_hours: reopenWindowHours,
       });
       showSuccess('Ticket settings saved');
     } catch (err) {
@@ -743,6 +749,40 @@ export default function Tickets({ guildId }: TicketsProps) {
                 onChange={setStaffRoles}
                 placeholder="Search roles…"
                 componentId="ticket-staff-roles"
+              />
+            </div>
+
+            <div>
+              <h5 className="text-sm font-medium text-gray-300 mb-1">Max Open Tickets per User</h5>
+              <p className="text-xs text-gray-500 mb-2">
+                Maximum concurrent open tickets allowed per user.
+              </p>
+              <input
+                type="number"
+                min={1}
+                value={maxOpenPerUser}
+                onChange={(event) => {
+                  const parsed = Number.parseInt(event.target.value, 10);
+                  setMaxOpenPerUser(Number.isNaN(parsed) ? 1 : Math.max(1, parsed));
+                }}
+                className="w-full px-3 py-2 bg-slate-700 text-white border border-slate-600 rounded"
+              />
+            </div>
+
+            <div>
+              <h5 className="text-sm font-medium text-gray-300 mb-1">Reopen Window (Hours)</h5>
+              <p className="text-xs text-gray-500 mb-2">
+                Hours after close when a ticket can still be reopened.
+              </p>
+              <input
+                type="number"
+                min={1}
+                value={reopenWindowHours}
+                onChange={(event) => {
+                  const parsed = Number.parseInt(event.target.value, 10);
+                  setReopenWindowHours(Number.isNaN(parsed) ? 1 : Math.max(1, parsed));
+                }}
+                className="w-full px-3 py-2 bg-slate-700 text-white border border-slate-600 rounded"
               />
             </div>
           </div>

--- a/web/frontend/src/pages/tickets/TicketList.test.tsx
+++ b/web/frontend/src/pages/tickets/TicketList.test.tsx
@@ -1,0 +1,95 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import TicketList from './TicketList';
+
+describe('TicketList', () => {
+  it('renders resolved creator identity and thread link', () => {
+    render(
+      <TicketList
+        tickets={[
+          {
+            id: 42,
+            guild_id: '123456789',
+            channel_id: '111111111',
+            thread_id: '222222222',
+            user_id: '999999999999',
+            creator_username: 'PilotOne',
+            creator_global_name: 'Admiral Pilot',
+            creator_discriminator: '0001',
+            category_id: 7,
+            status: 'open',
+            closed_by: null,
+            created_at: 1710000000,
+            closed_at: null,
+          },
+        ]}
+        categories={[
+          {
+            id: 7,
+            guild_id: '123456789',
+            name: 'Support',
+            description: 'Support queue',
+            welcome_message: 'Welcome',
+            role_ids: [],
+            prerequisite_role_ids_all: [],
+            prerequisite_role_ids_any: [],
+            emoji: null,
+            sort_order: 0,
+            created_at: 1710000000,
+            channel_id: '111111111',
+          },
+        ]}
+        ticketFilter=""
+        ticketPage={1}
+        ticketTotal={1}
+        onFilterChange={() => {}}
+        onPageChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tickets' }));
+
+    expect(screen.getByText('Admiral Pilot')).toBeInTheDocument();
+    expect(screen.getByText('PilotOne#0001')).toBeInTheDocument();
+    expect(screen.getByText('999999999999')).toBeInTheDocument();
+
+    const threadLink = screen.getByRole('link', { name: 'Open Thread' });
+    expect(threadLink).toHaveAttribute(
+      'href',
+      'https://discord.com/channels/123456789/222222222',
+    );
+  });
+
+  it('falls back to shortened user label when creator identity is unavailable', () => {
+    render(
+      <TicketList
+        tickets={[
+          {
+            id: 7,
+            guild_id: '333333333',
+            channel_id: '444444444',
+            thread_id: '555555555',
+            user_id: '123456789012',
+            category_id: null,
+            status: 'closed',
+            closed_by: null,
+            created_at: 1710000000,
+            closed_at: 1710003600,
+          },
+        ]}
+        categories={[]}
+        ticketFilter=""
+        ticketPage={1}
+        ticketTotal={1}
+        onFilterChange={() => {}}
+        onPageChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tickets' }));
+
+    expect(screen.getByText('User 789012')).toBeInTheDocument();
+  });
+});

--- a/web/frontend/src/pages/tickets/TicketList.tsx
+++ b/web/frontend/src/pages/tickets/TicketList.tsx
@@ -16,6 +16,30 @@ interface TicketListProps {
   onPageChange: (page: number) => void;
 }
 
+function getCreatorLabel(ticket: TicketInfo): string {
+  if (ticket.creator_global_name) {
+    return ticket.creator_global_name;
+  }
+  if (ticket.creator_username) {
+    return ticket.creator_username;
+  }
+  return `User ${ticket.user_id.slice(-6)}`;
+}
+
+function getCreatorTag(ticket: TicketInfo): string | null {
+  if (!ticket.creator_username) {
+    return null;
+  }
+  if (!ticket.creator_discriminator) {
+    return ticket.creator_username;
+  }
+  return `${ticket.creator_username}#${ticket.creator_discriminator}`;
+}
+
+function getThreadUrl(ticket: TicketInfo): string {
+  return `https://discord.com/channels/${ticket.guild_id}/${ticket.thread_id}`;
+}
+
 export default function TicketList({
   tickets,
   categories,
@@ -61,6 +85,7 @@ export default function TicketList({
                   <th className="text-left px-3 py-2 font-medium">ID</th>
                   <th className="text-left px-3 py-2 font-medium">Creator</th>
                   <th className="text-left px-3 py-2 font-medium">Category</th>
+                  <th className="text-left px-3 py-2 font-medium">Thread</th>
                   <th className="text-left px-3 py-2 font-medium">Status</th>
                   <th className="text-left px-3 py-2 font-medium">Created</th>
                   <th className="text-left px-3 py-2 font-medium">Closed</th>
@@ -73,11 +98,29 @@ export default function TicketList({
                     className="hover:bg-slate-700/30 transition-colors"
                   >
                     <td className="px-3 py-2 font-mono text-xs">{t.id}</td>
-                    <td className="px-3 py-2 font-mono text-xs text-gray-300">
-                      {t.user_id}
+                    <td className="px-3 py-2 text-xs text-gray-300">
+                      <div className="max-w-[220px] truncate font-medium text-gray-200">
+                        {getCreatorLabel(t)}
+                      </div>
+                      {getCreatorTag(t) && (
+                        <div className="max-w-[220px] truncate text-gray-400">
+                          {getCreatorTag(t)}
+                        </div>
+                      )}
+                      <div className="font-mono text-[11px] text-gray-500">{t.user_id}</div>
                     </td>
                     <td className="px-3 py-2">
                       {getCategoryName(t.category_id, categories)}
+                    </td>
+                    <td className="px-3 py-2 text-xs">
+                      <a
+                        href={getThreadUrl(t)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-indigo-300 hover:text-indigo-200 hover:underline"
+                      >
+                        Open Thread
+                      </a>
                     </td>
                     <td className="px-3 py-2">
                       <Badge variant={t.status === 'open' ? 'success' : 'neutral'}>


### PR DESCRIPTION
## Summary by Sourcery

Add leadership audit posting for deleted tickets, enrich ticket listings with creator metadata and thread links, and tighten ticket/open-count behavior around deleted threads while improving type safety and schema guards.

New Features:
- Post deleted ticket transcripts and audit embeds to the guild leadership channel when available.
- Expose ticket creator Discord identity details and direct thread links in the admin dashboard ticket list.
- Allow configuring maximum concurrent open tickets per user and ticket reopen window from the dashboard.

Bug Fixes:
- Exclude soft-deleted tickets from open ticket queries and open-ticket limit checks so deleted threads no longer block new tickets.
- Fix ticket statistics and thread health queries to use consistent row access, avoiding mixed tuple/dict handling issues.
- Handle RSI handle and organization HTML parsing more defensively when unexpected node types are returned.

Enhancements:
- Refine schema compatibility checks for ticket-related tables to use clearer double-checked locking and logging.
- Improve tests and helper fakes for interactions, admin status, verification flows, and game/user metrics with stronger typing and more realistic behavior.
- Align bulk verification recheck examples with the typed admin API client for clearer usage.