### PR TITLE
Refactor tests and enhance ticket reconciliation functionality

### DIFF
--- a/cogs/tickets/commands.py
+++ b/cogs/tickets/commands.py
@@ -152,11 +152,13 @@ class TicketCommands(commands.GroupCog, name="tickets"):
     async def _reconcile_missing_open_tickets(
         self,
         guild: discord.Guild,
+        limit: int | None = None,
     ) -> dict[str, int]:
         """Reconcile open ticket rows whose Discord threads are missing."""
         return await self.ticket_service.reconcile_missing_open_tickets(
             guild.id,
             lambda thread_id: guild_thread_exists(guild, thread_id),
+            limit=limit,
         )
 
     # ------------------------------------------------------------------
@@ -193,7 +195,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
         """
         for guild in self.bot.guilds:
             try:
-                await self._reconcile_missing_open_tickets(guild)
+                await self._reconcile_missing_open_tickets(guild, limit=50)
                 health = await self.ticket_service.get_thread_health(guild.id)
                 status = health["status"]
 
@@ -569,10 +571,19 @@ class TicketCommands(commands.GroupCog, name="tickets"):
             )
 
         if not candidates and not missing_open:
-            noun = "closed tickets" if not include_open else "tickets to repair"
+            if include_open:
+                description = (
+                    f"No closed ticket threads older than {max(older_than, 30)} days "
+                    "or stale open ticket rows found."
+                )
+            else:
+                description = (
+                    f"No closed ticket threads older than {max(older_than, 30)} days "
+                    "found."
+                )
             embed = create_embed(
                 title="🧹 Cleanup — Nothing to do",
-                description=(f"No {noun} older than {max(older_than, 30)} days found."),
+                description=description,
                 color=EmbedColors.INFO,
             )
             await interaction.followup.send(embed=embed, ephemeral=True)

--- a/cogs/tickets/commands.py
+++ b/cogs/tickets/commands.py
@@ -13,14 +13,14 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import discord  # type: ignore[import-not-found]
 from discord import app_commands  # type: ignore[import-not-found]
 from discord.ext import commands, tasks  # type: ignore[import-not-found]
 
 from helpers.decorators import require_permission_level
-from helpers.discord_api import channel_send_message
+from helpers.discord_api import channel_send_message, guild_thread_exists
 from helpers.embeds import EmbedColors, create_embed
 from helpers.leadership_log import resolve_leadership_channel
 from helpers.permissions_helper import PermissionLevel
@@ -149,6 +149,16 @@ class TicketCommands(commands.GroupCog, name="tickets"):
         """Shortcut to TicketFormService."""
         return self.bot.services.ticket_form
 
+    async def _reconcile_missing_open_tickets(
+        self,
+        guild: discord.Guild,
+    ) -> dict[str, int]:
+        """Reconcile open ticket rows whose Discord threads are missing."""
+        return await self.ticket_service.reconcile_missing_open_tickets(
+            guild.id,
+            lambda thread_id: guild_thread_exists(guild, thread_id),
+        )
+
     # ------------------------------------------------------------------
     # Periodic cleanup of expired route sessions
     # ------------------------------------------------------------------
@@ -183,6 +193,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
         """
         for guild in self.bot.guilds:
             try:
+                await self._reconcile_missing_open_tickets(guild)
                 health = await self.ticket_service.get_thread_health(guild.id)
                 status = health["status"]
 
@@ -195,9 +206,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
                 # Avoid duplicate alerts for the same severity
                 severity_order = {"notice": 1, "warning": 2, "critical": 3}
                 current = severity_order.get(status, 0)
-                last = severity_order.get(
-                    self._last_alert_level.get(guild.id, ""), 0
-                )
+                last = severity_order.get(self._last_alert_level.get(guild.id, ""), 0)
                 if current <= last:
                     continue
 
@@ -251,11 +260,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
                 "Use `/tickets health` for details or "
                 "`/tickets cleanup` to remove old threads."
             ),
-            color=(
-                EmbedColors.ERROR
-                if status == "critical"
-                else EmbedColors.WARNING
-            ),
+            color=(EmbedColors.ERROR if status == "critical" else EmbedColors.WARNING),
         )
 
         channel = await resolve_leadership_channel(self.bot, guild.id)
@@ -304,9 +309,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
         for guild in targets:
             try:
                 # Discover all channels that have ticket categories
-                channel_ids = await self.ticket_service.get_ticket_channel_ids(
-                    guild.id
-                )
+                channel_ids = await self.ticket_service.get_ticket_channel_ids(guild.id)
 
                 # Fall back to legacy single-channel setting
                 if not channel_ids:
@@ -321,9 +324,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
 
                 for chan_id in channel_ids:
                     channel = guild.get_channel(chan_id)
-                    if channel is None or not isinstance(
-                        channel, discord.TextChannel
-                    ):
+                    if channel is None or not isinstance(channel, discord.TextChannel):
                         continue
 
                     existing_msg_id = panel_ids.get((guild.id, chan_id))
@@ -358,17 +359,11 @@ class TicketCommands(commands.GroupCog, name="tickets"):
         channel_config = await self.ticket_service.get_channel_config(
             guild.id, channel.id
         )
-        title = (
-            (channel_config or {}).get("panel_title")
-            or "🎫 Support Tickets"
-        )
-        description = (
-            (channel_config or {}).get("panel_description")
-            or (
-                "Need help? Click the button below to open a support ticket.\n\n"
-                "A private thread will be created for you and a staff member "
-                "will assist you as soon as possible."
-            )
+        title = (channel_config or {}).get("panel_title") or "🎫 Support Tickets"
+        description = (channel_config or {}).get("panel_description") or (
+            "Need help? Click the button below to open a support ticket.\n\n"
+            "A private thread will be created for you and a staff member "
+            "will assist you as soon as possible."
         )
 
         embed = create_embed(
@@ -388,9 +383,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
             public_button_text=(channel_config or {}).get(
                 "public_button_text", "Create Public Ticket"
             ),
-            public_button_emoji=(channel_config or {}).get(
-                "public_button_emoji", "🌐"
-            ),
+            public_button_emoji=(channel_config or {}).get("public_button_emoji", "🌐"),
             private_button_color=(channel_config or {}).get("private_button_color"),
             public_button_color=(channel_config or {}).get("public_button_color"),
             button_order=(channel_config or {}).get("button_order", "private_first"),
@@ -442,6 +435,8 @@ class TicketCommands(commands.GroupCog, name="tickets"):
             )
             return
 
+        await self._reconcile_missing_open_tickets(guild)
+
         data = await self.ticket_service.get_ticket_stats(guild.id)
         health = await self.ticket_service.get_thread_health(guild.id)
         embed = create_embed(
@@ -481,10 +476,10 @@ class TicketCommands(commands.GroupCog, name="tickets"):
             )
             return
 
+        await self._reconcile_missing_open_tickets(guild)
+
         health = await self.ticket_service.get_thread_health(guild.id)
-        oldest = await self.ticket_service.get_oldest_closed_tickets(
-            guild.id, limit=5
-        )
+        oldest = await self.ticket_service.get_oldest_closed_tickets(guild.id, limit=5)
 
         status_emoji = {
             "healthy": "✅",
@@ -509,9 +504,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
                 closed_ts = t.get("closed_at")
                 if closed_ts:
                     days_ago = (int(time.time()) - int(closed_ts)) // 86400
-                    lines.append(
-                        f"• <#{t['thread_id']}> — closed {days_ago}d ago"
-                    )
+                    lines.append(f"• <#{t['thread_id']}> — closed {days_ago}d ago")
 
         embed = create_embed(
             title="🏥 Thread Health",
@@ -537,6 +530,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
     @app_commands.describe(
         older_than="Minimum days since ticket was closed (min 30).",
         dry_run="Preview only — do not actually delete threads.",
+        include_open="Also repair open tickets whose threads no longer exist.",
     )
     @app_commands.guild_only()
     @require_permission_level(PermissionLevel.BOT_ADMIN)
@@ -545,6 +539,7 @@ class TicketCommands(commands.GroupCog, name="tickets"):
         interaction: discord.Interaction,
         older_than: int = 90,
         dry_run: bool = True,
+        include_open: bool = False,
     ) -> None:
         """Delete Discord threads for old closed tickets.
 
@@ -565,41 +560,55 @@ class TicketCommands(commands.GroupCog, name="tickets"):
         candidates = await self.ticket_service.get_cleanup_candidates(
             guild.id, older_than_days=older_than
         )
+        missing_open: list[dict[str, Any]] = []
 
-        if not candidates:
+        if include_open:
+            missing_open = await self.ticket_service.get_missing_open_tickets(
+                guild.id,
+                lambda thread_id: guild_thread_exists(guild, thread_id),
+            )
+
+        if not candidates and not missing_open:
+            noun = "closed tickets" if not include_open else "tickets to repair"
             embed = create_embed(
                 title="🧹 Cleanup — Nothing to do",
-                description=(
-                    f"No closed tickets older than {max(older_than, 30)} "
-                    "days found."
-                ),
+                description=(f"No {noun} older than {max(older_than, 30)} days found."),
                 color=EmbedColors.INFO,
             )
             await interaction.followup.send(embed=embed, ephemeral=True)
             return
 
         if dry_run:
-            lines = [
-                f"Found **{len(candidates)}** thread(s) eligible for deletion "
-                f"(closed >{max(older_than, 30)} days ago):\n"
-            ]
-            for t in candidates[:25]:  # cap preview
-                closed_ts = t.get("closed_at")
-                days_ago = (
-                    (int(time.time()) - int(closed_ts)) // 86400
-                    if closed_ts
-                    else "?"
-                )
+            lines: list[str] = []
+            if candidates:
                 lines.append(
-                    f"• <#{t['thread_id']}> — closed {days_ago}d ago"
+                    f"Found **{len(candidates)}** thread(s) eligible for "
+                    f"deletion (closed >{max(older_than, 30)} days ago):\n"
                 )
-            if len(candidates) > 25:
+                for t in candidates[:25]:  # cap preview
+                    closed_ts = t.get("closed_at")
+                    days_ago = (
+                        (int(time.time()) - int(closed_ts)) // 86400
+                        if closed_ts
+                        else "?"
+                    )
+                    lines.append(f"• <#{t['thread_id']}> — closed {days_ago}d ago")
+                if len(candidates) > 25:
+                    lines.append(f"\n…and {len(candidates) - 25} more.")
+
+            if include_open and missing_open:
+                if lines:
+                    lines.append("")
                 lines.append(
-                    f"\n…and {len(candidates) - 25} more."
+                    f"Found **{len(missing_open)}** open ticket(s) whose "
+                    "threads are missing from Discord:\n"
                 )
-            lines.append(
-                "\nRe-run with `dry_run: False` to delete these threads."
-            )
+                for ticket in missing_open[:25]:
+                    lines.append(f"• <#{ticket['thread_id']}> — stale open row")
+                if len(missing_open) > 25:
+                    lines.append(f"\n…and {len(missing_open) - 25} more.")
+
+            lines.append("\nRe-run with `dry_run: False` to apply these repairs.")
             embed = create_embed(
                 title="🧹 Cleanup — Dry Run",
                 description="\n".join(lines),
@@ -633,9 +642,17 @@ class TicketCommands(commands.GroupCog, name="tickets"):
                 )
                 failed += 1
 
+        repaired = 0
+        if include_open:
+            repair_report = await self._reconcile_missing_open_tickets(guild)
+            repaired = repair_report["reconciled"]
+            failed += repair_report["failed"]
+
         desc = f"Deleted **{deleted}** thread(s)."
+        if repaired:
+            desc += f"\nRepaired **{repaired}** stale open ticket(s)."
         if failed:
-            desc += f"\n**{failed}** thread(s) could not be deleted."
+            desc += f"\n**{failed}** thread(s) could not be deleted or repaired."
 
         embed = create_embed(
             title="🧹 Cleanup Complete",

--- a/helpers/discord_api.py
+++ b/helpers/discord_api.py
@@ -13,6 +13,34 @@ Enqueues each call so they're rate-limited via task_queue.py.
 """
 
 
+async def guild_thread_exists(guild: discord.Guild, thread_id: int) -> bool:
+    """Return whether a thread exists, failing open on permission/API errors."""
+    get_thread = getattr(guild, "get_thread", None)
+    if callable(get_thread) and get_thread(thread_id) is not None:
+        return True
+
+    try:
+        await guild.fetch_channel(thread_id)
+        return True
+    except discord.NotFound:
+        return False
+    except discord.Forbidden:
+        logger.warning(
+            "Missing permissions to verify thread %s in guild %s",
+            thread_id,
+            guild.id,
+        )
+        return True
+    except discord.HTTPException as e:
+        logger.exception(
+            "Failed to verify thread %s in guild %s",
+            thread_id,
+            guild.id,
+            exc_info=e,
+        )
+        return True
+
+
 async def delete_channel(channel: discord.abc.GuildChannel) -> None:
     async def _task() -> None:
         # Check if the channel still exists before deleting

--- a/helpers/ticket_views.py
+++ b/helpers/ticket_views.py
@@ -33,6 +33,7 @@ from discord.ui import (
     View,
 )
 
+from helpers.discord_api import guild_thread_exists
 from helpers.embeds import EmbedColors, create_embed
 from helpers.leadership_log import resolve_leadership_channel
 from services.ticket_service import (
@@ -152,9 +153,7 @@ async def _post_deleted_ticket_transcript(
             return
 
         creator_id = ticket.get("user_id")
-        creator_line = (
-            f"<@{creator_id}>" if isinstance(creator_id, int) else "unknown"
-        )
+        creator_line = f"<@{creator_id}>" if isinstance(creator_id, int) else "unknown"
         embed = create_embed(
             title="🗑️ Ticket Deleted",
             description=(
@@ -393,8 +392,12 @@ class TicketPanelView(View):
         self.bot = bot
 
         # Convert color hex codes to Discord button styles
-        private_style = self._color_to_button_style(private_button_color, discord.ButtonStyle.primary)
-        public_style = self._color_to_button_style(public_button_color, discord.ButtonStyle.secondary)
+        private_style = self._color_to_button_style(
+            private_button_color, discord.ButtonStyle.primary
+        )
+        public_style = self._color_to_button_style(
+            public_button_color, discord.ButtonStyle.secondary
+        )
 
         create_btn: Button = Button(
             label=private_button_text,
@@ -424,7 +427,9 @@ class TicketPanelView(View):
                 self.add_item(public_btn)
 
     @staticmethod
-    def _color_to_button_style(color: str | None, default: discord.ButtonStyle) -> discord.ButtonStyle:
+    def _color_to_button_style(
+        color: str | None, default: discord.ButtonStyle
+    ) -> discord.ButtonStyle:
         """Convert a hex color code to a Discord button style.
 
         Supports common color mappings:
@@ -442,7 +447,13 @@ class TicketPanelView(View):
         normalized = color.strip().upper().lstrip("#")
 
         # Map common colors to button styles
-        if normalized in ("5865F2", "5865F3", "5865F4", "0099FF", "3B88F3"):  # Blue/Blurple
+        if normalized in (
+            "5865F2",
+            "5865F3",
+            "5865F4",
+            "0099FF",
+            "3B88F3",
+        ):  # Blue/Blurple
             return discord.ButtonStyle.primary
         elif normalized in ("4E5058", "4F545C", "6C757D", "2C2F33"):  # Gray
             return discord.ButtonStyle.secondary
@@ -483,6 +494,12 @@ class TicketPanelView(View):
         guild_id = interaction.guild.id
         ticket_service = self.bot.services.ticket
         config_service = self.bot.services.config
+        guild = interaction.guild
+
+        await ticket_service.reconcile_missing_open_tickets(
+            guild_id,
+            lambda thread_id: guild_thread_exists(guild, thread_id),
+        )
 
         # --- Rate-limit check ---
         allowed = await ticket_service.check_rate_limit(guild_id, interaction.user.id)
@@ -498,7 +515,9 @@ class TicketPanelView(View):
 
         # --- Max open tickets check ---
         max_open_raw = await config_service.get_guild_setting(
-            guild_id, "tickets.max_open_per_user", default=str(DEFAULT_MAX_OPEN_PER_USER)
+            guild_id,
+            "tickets.max_open_per_user",
+            default=str(DEFAULT_MAX_OPEN_PER_USER),
         )
         try:
             max_open = int(max_open_raw)
@@ -840,7 +859,9 @@ class TicketActionView(View):
         is_staff = False
 
         if isinstance(interaction.user, discord.Member):
-            category_role_ids = await _get_ticket_category_role_ids(ticket_service, ticket)
+            category_role_ids = await _get_ticket_category_role_ids(
+                ticket_service, ticket
+            )
             is_staff = await _get_staff_and_check(
                 self.bot,
                 guild_id,
@@ -885,7 +906,9 @@ class TicketActionView(View):
         is_creator = user_id == ticket["user_id"]
         is_staff = False
         if isinstance(interaction.user, discord.Member):
-            category_role_ids = await _get_ticket_category_role_ids(ticket_service, ticket)
+            category_role_ids = await _get_ticket_category_role_ids(
+                ticket_service, ticket
+            )
             is_staff = await _get_staff_and_check(
                 self.bot,
                 guild_id,
@@ -901,7 +924,9 @@ class TicketActionView(View):
 
         # Check reopen window
         reopen_window_raw = await config_service.get_guild_setting(
-            guild_id, "tickets.reopen_window_hours", default=str(DEFAULT_REOPEN_WINDOW_HOURS)
+            guild_id,
+            "tickets.reopen_window_hours",
+            default=str(DEFAULT_REOPEN_WINDOW_HOURS),
         )
         try:
             reopen_window = int(reopen_window_raw)
@@ -984,7 +1009,9 @@ class TicketActionView(View):
         is_creator = user_id == ticket["user_id"]
         is_staff = False
         if isinstance(interaction.user, discord.Member):
-            category_role_ids = await _get_ticket_category_role_ids(ticket_service, ticket)
+            category_role_ids = await _get_ticket_category_role_ids(
+                ticket_service, ticket
+            )
             is_staff = await _get_staff_and_check(
                 self.bot,
                 guild_id,
@@ -1013,10 +1040,7 @@ class TicketActionView(View):
 
         try:
             await thread.delete(
-                reason=(
-                    f"Ticket deleted by {interaction.user} "
-                    f"({interaction.user.id})"
-                )
+                reason=(f"Ticket deleted by {interaction.user} ({interaction.user.id})")
             )
         except discord.Forbidden as e:
             logger.exception(
@@ -1059,8 +1083,7 @@ class TicketActionView(View):
             guild_id,
             title="🗑️ Ticket Deleted",
             description=(
-                f"**Thread:** `{thread.id}`\n"
-                f"**Deleted by:** {interaction.user.mention}"
+                f"**Thread:** `{thread.id}`\n**Deleted by:** {interaction.user.mention}"
             ),
             color=EmbedColors.WARNING,
         )
@@ -1097,7 +1120,9 @@ async def _start_dynamic_form(
 
     # Create fresh session
     ctx = await ticket_form_service.create_session(
-        guild_id, user_id, category["id"],
+        guild_id,
+        user_id,
+        category["id"],
         interaction_token=interaction.token,
         is_public=is_public,
     )
@@ -1220,9 +1245,7 @@ async def _create_ticket_thread(
     try:
         await thread.add_user(user)
     except discord.Forbidden:
-        logger.debug(
-            "No permission to add user %s to thread %s", user.id, thread.id
-        )
+        logger.debug("No permission to add user %s to thread %s", user.id, thread.id)
     except discord.HTTPException as exc:
         logger.warning(
             "Could not add user %s to thread %s: %s",

--- a/helpers/ticket_views.py
+++ b/helpers/ticket_views.py
@@ -499,6 +499,7 @@ class TicketPanelView(View):
         await ticket_service.reconcile_missing_open_tickets(
             guild_id,
             lambda thread_id: guild_thread_exists(guild, thread_id),
+            limit=20,
         )
 
         # --- Rate-limit check ---

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -997,6 +997,20 @@ class TicketService(BaseService):
         if limit is not None:
             tickets = tickets[:limit]
 
+        return await self._find_missing_open_tickets(
+            guild_id,
+            tickets,
+            thread_exists,
+        )
+
+    async def _find_missing_open_tickets(
+        self,
+        guild_id: int,
+        tickets: list[dict[str, Any]],
+        thread_exists: Callable[[int], bool | Awaitable[bool]],
+    ) -> list[dict[str, Any]]:
+        """Return already-fetched open tickets whose Discord threads are missing."""
+
         missing: list[dict[str, Any]] = []
         for ticket in tickets:
             thread_id = int(ticket["thread_id"])
@@ -1025,10 +1039,10 @@ class TicketService(BaseService):
         if limit is not None:
             open_tickets = open_tickets[:limit]
 
-        missing = await self.get_missing_open_tickets(
+        missing = await self._find_missing_open_tickets(
             guild_id,
+            open_tickets,
             thread_exists,
-            limit=limit,
         )
 
         reconciled = 0

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -9,16 +9,20 @@ reopening, transcripts, and statistics.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import sqlite3
 import time
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from helpers.role_ids import normalize_role_id_list
 from services.base import BaseService
 from services.db.database import Database
 from services.db.repository import BaseRepository
 from services.db.schema import ensure_ticket_schema_compatibility
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
 
 # Default rate-limit: one ticket per 5 minutes (300 seconds)
 TICKET_RATE_LIMIT_SECONDS = 300
@@ -38,31 +42,69 @@ DEFAULT_THREAD_LIMIT = 1000
 # Special user_id used for guild-wide cooldown reset markers.
 _GLOBAL_COOLDOWN_RESET_USER_ID = 0
 
+# Special user_id used when the bot reconciles orphaned tickets.
+_SYSTEM_RECONCILE_USER_ID = 0
+
 # Column names for ticket SELECT queries — keep in sync with _row_to_ticket()
 _TICKET_COLUMN_NAMES = [
-    "id", "guild_id", "channel_id", "thread_id", "user_id",
-    "category_id", "status", "closed_by", "created_at", "closed_at",
-    "claimed_by", "claimed_at", "close_reason", "initial_description",
-    "reopened_at", "reopened_by", "deleted_at",
+    "id",
+    "guild_id",
+    "channel_id",
+    "thread_id",
+    "user_id",
+    "category_id",
+    "status",
+    "closed_by",
+    "created_at",
+    "closed_at",
+    "claimed_by",
+    "claimed_at",
+    "close_reason",
+    "initial_description",
+    "reopened_at",
+    "reopened_by",
+    "deleted_at",
 ]
 _TICKET_COLUMNS = ", ".join(_TICKET_COLUMN_NAMES)
 
 # Column names for category SELECT queries — keep in sync with _row_to_category()
 _CATEGORY_COLUMN_NAMES = [
-    "id", "guild_id", "channel_id", "name", "description", "welcome_message",
-    "role_ids", "prerequisite_role_ids_all", "prerequisite_role_ids_any",
-    "emoji", "sort_order", "created_at",
+    "id",
+    "guild_id",
+    "channel_id",
+    "name",
+    "description",
+    "welcome_message",
+    "role_ids",
+    "prerequisite_role_ids_all",
+    "prerequisite_role_ids_any",
+    "emoji",
+    "sort_order",
+    "created_at",
 ]
 _CATEGORY_COLUMNS = ", ".join(_CATEGORY_COLUMN_NAMES)
 
 # Column names for channel config SELECT queries — keep in sync with _row_to_channel_config()
 _CHANNEL_CONFIG_COLUMN_NAMES = [
-    "id", "guild_id", "channel_id", "panel_title", "panel_description",
-    "panel_color", "button_text", "button_emoji", "enable_public_button",
-    "public_button_text", "public_button_emoji", "private_button_color",
-    "public_button_color", "button_order", "sort_order", "created_at",
+    "id",
+    "guild_id",
+    "channel_id",
+    "panel_title",
+    "panel_description",
+    "panel_color",
+    "button_text",
+    "button_emoji",
+    "enable_public_button",
+    "public_button_text",
+    "public_button_emoji",
+    "private_button_color",
+    "public_button_color",
+    "button_order",
+    "sort_order",
+    "created_at",
 ]
 _CHANNEL_CONFIG_COLUMNS = ", ".join(_CHANNEL_CONFIG_COLUMN_NAMES)
+
 
 class TicketService(BaseService):
     """Service for managing the thread-based ticketing system.
@@ -766,7 +808,14 @@ class TicketService(BaseService):
                     (guild_id, channel_id, thread_id, user_id, category_id, initial_description)
                 VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (guild_id, channel_id, thread_id, user_id, category_id, initial_description),
+                (
+                    guild_id,
+                    channel_id,
+                    thread_id,
+                    user_id,
+                    category_id,
+                    initial_description,
+                ),
             )
             self.logger.info(
                 "Created ticket %s (thread=%s) for user %s in guild %s",
@@ -813,14 +862,10 @@ class TicketService(BaseService):
                 (closed_by, now, close_reason, ticket_id),
             )
             if rows > 0:
-                self.logger.info(
-                    "Closed ticket %s by user %s", ticket_id, closed_by
-                )
+                self.logger.info("Closed ticket %s by user %s", ticket_id, closed_by)
             return rows > 0
         except Exception as e:
-            self.logger.exception(
-                "Failed to close ticket %s", ticket_id, exc_info=e
-            )
+            self.logger.exception("Failed to close ticket %s", ticket_id, exc_info=e)
             return False
 
     async def close_ticket_by_thread(
@@ -930,6 +975,93 @@ class TicketService(BaseService):
         )
         return [self._row_to_ticket(r) for r in rows]
 
+    @staticmethod
+    async def _thread_exists(
+        thread_exists: Callable[[int], bool | Awaitable[bool]],
+        thread_id: int,
+    ) -> bool:
+        """Resolve a synchronous or async thread-existence callback."""
+        result = thread_exists(thread_id)
+        if inspect.isawaitable(result):
+            return bool(await cast("Awaitable[bool]", result))
+        return bool(result)
+
+    async def get_missing_open_tickets(
+        self,
+        guild_id: int,
+        thread_exists: Callable[[int], bool | Awaitable[bool]],
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return open tickets whose Discord threads can no longer be found."""
+        tickets = await self.get_open_tickets(guild_id)
+        if limit is not None:
+            tickets = tickets[:limit]
+
+        missing: list[dict[str, Any]] = []
+        for ticket in tickets:
+            thread_id = int(ticket["thread_id"])
+            try:
+                exists = await self._thread_exists(thread_exists, thread_id)
+            except Exception as e:
+                self.logger.exception(
+                    "Failed to check thread %s for guild %s",
+                    thread_id,
+                    guild_id,
+                    exc_info=e,
+                )
+                continue
+            if not exists:
+                missing.append(ticket)
+        return missing
+
+    async def reconcile_missing_open_tickets(
+        self,
+        guild_id: int,
+        thread_exists: Callable[[int], bool | Awaitable[bool]],
+        limit: int | None = None,
+    ) -> dict[str, int]:
+        """Close and soft-delete open tickets whose Discord threads are gone."""
+        open_tickets = await self.get_open_tickets(guild_id)
+        if limit is not None:
+            open_tickets = open_tickets[:limit]
+
+        missing = await self.get_missing_open_tickets(
+            guild_id,
+            thread_exists,
+            limit=limit,
+        )
+
+        reconciled = 0
+        failed = 0
+        for ticket in missing:
+            thread_id = int(ticket["thread_id"])
+            try:
+                closed = await self.close_ticket_by_thread(
+                    thread_id,
+                    closed_by=_SYSTEM_RECONCILE_USER_ID,
+                    close_reason="Discord thread no longer exists",
+                )
+                deleted = await self.mark_thread_deleted(thread_id)
+                if closed or deleted:
+                    reconciled += 1
+                else:
+                    failed += 1
+            except Exception as e:
+                failed += 1
+                self.logger.exception(
+                    "Failed to reconcile missing open thread %s in guild %s",
+                    thread_id,
+                    guild_id,
+                    exc_info=e,
+                )
+
+        return {
+            "checked": len(open_tickets),
+            "missing": len(missing),
+            "reconciled": reconciled,
+            "failed": failed,
+        }
+
     async def get_tickets(
         self,
         guild_id: int,
@@ -948,7 +1080,7 @@ class TicketService(BaseService):
         Returns:
             List of ticket dicts.
         """
-        where = "WHERE guild_id = ?"
+        where = "WHERE guild_id = ? AND deleted_at IS NULL"
         params: list[Any] = [guild_id]
         if status:
             where += " AND status = ?"
@@ -967,7 +1099,7 @@ class TicketService(BaseService):
         status: str | None = None,
     ) -> int:
         """Return total ticket count, optionally filtered by status."""
-        where = "WHERE guild_id = ?"
+        where = "WHERE guild_id = ? AND deleted_at IS NULL"
         params: list[Any] = [guild_id]
         if status:
             where += " AND status = ?"
@@ -988,7 +1120,7 @@ class TicketService(BaseService):
         """
         rows = await BaseRepository.fetch_all(
             "SELECT status, COUNT(*) AS cnt FROM tickets "
-            "WHERE guild_id = ? GROUP BY status",
+            "WHERE guild_id = ? AND deleted_at IS NULL GROUP BY status",
             (guild_id,),
         )
         counts: dict[str, int] = {"open": 0, "closed": 0}
@@ -1049,7 +1181,9 @@ class TicketService(BaseService):
         archived = int((row_data["archived"] if row_data is not None else 0) or 0)
         deleted = int((row_data["deleted"] if row_data is not None else 0) or 0)
         total_threads = active + archived
-        usage_pct = round((total_threads / thread_limit) * 100, 1) if thread_limit else 0
+        usage_pct = (
+            round((total_threads / thread_limit) * 100, 1) if thread_limit else 0
+        )
 
         if usage_pct >= 95:
             status = "critical"
@@ -1374,7 +1508,9 @@ class TicketService(BaseService):
                                 "ALTER TABLE tickets "
                                 "ADD COLUMN deleted_at INTEGER DEFAULT NULL"
                             )
-                            self.logger.info("Added missing deleted_at column to tickets")
+                            self.logger.info(
+                                "Added missing deleted_at column to tickets"
+                            )
                         except sqlite3.OperationalError as e:
                             if "duplicate column name" not in str(e).lower():
                                 raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from services.config_service import ConfigService
 from services.db.database import Database
 from services.voice_service import VoiceService
-from tests.test_helpers import FakeInteraction, FakeUser
+from tests.test_helpers import FakeInteraction, FakeUser  # noqa: F401
 
 
 @pytest.fixture

--- a/tests/test_ticket_commands.py
+++ b/tests/test_ticket_commands.py
@@ -62,6 +62,7 @@ def _make_bot() -> MagicMock:
     )
     ts.get_oldest_closed_tickets = AsyncMock(return_value=[])
     ts.get_cleanup_candidates = AsyncMock(return_value=[])
+    ts.get_missing_open_tickets = AsyncMock(return_value=[])
     ts.mark_thread_deleted = AsyncMock(return_value=True)
     ts.reconcile_missing_open_tickets = AsyncMock(
         return_value={
@@ -225,6 +226,32 @@ class TestTicketCommandsCleanup:
         assert "Nothing to do" in embed.title
 
     @pytest.mark.asyncio
+    async def test_cleanup_include_open_no_candidates_names_both_sets(self) -> None:
+        """Dry run with open repair enabled names closed and stale-open checks."""
+        bot = _make_bot()
+        bot.services.ticket.get_cleanup_candidates = AsyncMock(return_value=[])
+        bot.services.ticket.get_missing_open_tickets = AsyncMock(return_value=[])
+
+        with patch("cogs.tickets.commands.spawn"):
+            from cogs.tickets.commands import TicketCommands
+
+            cog = TicketCommands(bot)
+
+        interaction = _interaction_with_guild()
+        cleanup_callback: Any = cog.cleanup.callback
+        await cleanup_callback(
+            cog,
+            interaction,
+            older_than=30,
+            dry_run=True,
+            include_open=True,
+        )
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        assert "closed ticket threads older than 30 days" in embed.description
+        assert "stale open ticket rows" in embed.description
+
+    @pytest.mark.asyncio
     async def test_cleanup_dry_run_with_candidates(self) -> None:
         """Dry run with candidates shows preview list."""
         bot = _make_bot()
@@ -349,6 +376,9 @@ class TestThreadHealthCheckTask:
 
         # No alert level should be stored
         assert guild.id not in cog._last_alert_level
+        bot.services.ticket.reconcile_missing_open_tickets.assert_awaited_once()
+        call_kwargs = bot.services.ticket.reconcile_missing_open_tickets.call_args.kwargs
+        assert call_kwargs["limit"] == 50
 
     @pytest.mark.asyncio
     async def test_warning_status_sends_alert(self) -> None:

--- a/tests/test_ticket_commands.py
+++ b/tests/test_ticket_commands.py
@@ -63,6 +63,14 @@ def _make_bot() -> MagicMock:
     ts.get_oldest_closed_tickets = AsyncMock(return_value=[])
     ts.get_cleanup_candidates = AsyncMock(return_value=[])
     ts.mark_thread_deleted = AsyncMock(return_value=True)
+    ts.reconcile_missing_open_tickets = AsyncMock(
+        return_value={
+            "checked": 0,
+            "missing": 0,
+            "reconciled": 0,
+            "failed": 0,
+        }
+    )
     bot.services.ticket = ts
 
     # ConfigService mock
@@ -280,6 +288,43 @@ class TestTicketCommandsCleanup:
         embed = interaction.followup.send.call_args.kwargs["embed"]
         assert "Complete" in embed.title
         bot.services.ticket.mark_thread_deleted.assert_awaited_once_with(51001)
+
+    @pytest.mark.asyncio
+    async def test_cleanup_include_open_reconciles_missing_threads(self) -> None:
+        """Cleanup can also repair stale open tickets when requested."""
+        bot = _make_bot()
+        bot.services.ticket.get_cleanup_candidates = AsyncMock(return_value=[])
+        bot.services.ticket.get_missing_open_tickets = AsyncMock(
+            return_value=[{"thread_id": 52001, "created_at": int(time.time())}],
+        )
+        bot.services.ticket.reconcile_missing_open_tickets = AsyncMock(
+            return_value={
+                "checked": 1,
+                "missing": 1,
+                "reconciled": 1,
+                "failed": 0,
+            }
+        )
+
+        with patch("cogs.tickets.commands.spawn"):
+            from cogs.tickets.commands import TicketCommands
+
+            cog = TicketCommands(bot)
+
+        interaction = _interaction_with_guild()
+        cleanup_callback: Any = cog.cleanup.callback
+        await cleanup_callback(
+            cog,
+            interaction,
+            older_than=30,
+            dry_run=False,
+            include_open=True,
+        )
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        assert "Complete" in embed.title
+        assert "Repaired" in embed.description
+        bot.services.ticket.reconcile_missing_open_tickets.assert_awaited_once()
 
 
 class TestThreadHealthCheckTask:

--- a/tests/test_ticket_service.py
+++ b/tests/test_ticket_service.py
@@ -248,7 +248,9 @@ class TestTicketLifecycle:
         assert ticket["status"] == "open"
 
     @pytest.mark.asyncio
-    async def test_get_ticket_by_thread_not_found(self, ticket_svc: TicketService) -> None:
+    async def test_get_ticket_by_thread_not_found(
+        self, ticket_svc: TicketService
+    ) -> None:
         """Non-existent thread ID returns None."""
         assert await ticket_svc.get_ticket_by_thread(99999) is None
 
@@ -355,6 +357,20 @@ class TestTicketQueries:
         assert len(closed_t) == 1
 
     @pytest.mark.asyncio
+    async def test_get_tickets_excludes_deleted(
+        self, ticket_svc: TicketService
+    ) -> None:
+        """Generic ticket lists exclude soft-deleted ticket rows."""
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 10011, USER_ID)
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 10012, USER_ID)
+        await ticket_svc.mark_thread_deleted(10012)
+
+        tickets = await ticket_svc.get_tickets(GUILD_ID)
+
+        assert len(tickets) == 1
+        assert tickets[0]["thread_id"] == 10011
+
+    @pytest.mark.asyncio
     async def test_get_ticket_count(self, ticket_svc: TicketService) -> None:
         """Counting tickets by status."""
         await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 11001, USER_ID)
@@ -365,6 +381,17 @@ class TestTicketQueries:
         assert await ticket_svc.get_ticket_count(GUILD_ID) == 2
         assert await ticket_svc.get_ticket_count(GUILD_ID, status="open") == 1
         assert await ticket_svc.get_ticket_count(GUILD_ID, status="closed") == 1
+
+    @pytest.mark.asyncio
+    async def test_get_ticket_count_excludes_deleted(
+        self, ticket_svc: TicketService
+    ) -> None:
+        """Generic ticket counts exclude soft-deleted ticket rows."""
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 11011, USER_ID)
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 11012, USER_ID)
+        await ticket_svc.mark_thread_deleted(11012)
+
+        assert await ticket_svc.get_ticket_count(GUILD_ID) == 1
 
     @pytest.mark.asyncio
     async def test_get_ticket_stats(self, ticket_svc: TicketService) -> None:
@@ -379,6 +406,21 @@ class TestTicketQueries:
         assert stats["closed"] == 1
         assert stats["total"] == 2
 
+    @pytest.mark.asyncio
+    async def test_get_ticket_stats_excludes_deleted(
+        self, ticket_svc: TicketService
+    ) -> None:
+        """Ticket stats exclude soft-deleted ticket rows."""
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 12011, USER_ID)
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 12012, USER_ID)
+        await ticket_svc.mark_thread_deleted(12012)
+
+        stats = await ticket_svc.get_ticket_stats(GUILD_ID)
+
+        assert stats["open"] == 1
+        assert stats["closed"] == 0
+        assert stats["total"] == 1
+
 
 # ---------------------------------------------------------------------------
 # Rate Limiting
@@ -389,7 +431,9 @@ class TestRateLimit:
     """Tests for the 5-minute per-user rate limit."""
 
     @pytest.mark.asyncio
-    async def test_rate_limit_allows_first_ticket(self, ticket_svc: TicketService) -> None:
+    async def test_rate_limit_allows_first_ticket(
+        self, ticket_svc: TicketService
+    ) -> None:
         """First ticket should always be allowed."""
         assert await ticket_svc.check_rate_limit(GUILD_ID, USER_ID) is True
 
@@ -470,14 +514,18 @@ class TestCloseReason:
         """Closing a ticket with a reason stores it."""
         tid = await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 17001, USER_ID)
         assert tid is not None
-        closed = await ticket_svc.close_ticket(tid, closed_by=999, close_reason="Resolved")
+        closed = await ticket_svc.close_ticket(
+            tid, closed_by=999, close_reason="Resolved"
+        )
         assert closed is True
         ticket = await ticket_svc.get_ticket_by_thread(17001)
         assert ticket is not None
         assert ticket["close_reason"] == "Resolved"
 
     @pytest.mark.asyncio
-    async def test_close_ticket_by_thread_with_reason(self, ticket_svc: TicketService) -> None:
+    async def test_close_ticket_by_thread_with_reason(
+        self, ticket_svc: TicketService
+    ) -> None:
         """close_ticket_by_thread with reason stores it."""
         await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 17002, USER_ID)
         closed = await ticket_svc.close_ticket_by_thread(
@@ -508,10 +556,15 @@ class TestInitialDescription:
     """Tests for initial_description on ticket creation."""
 
     @pytest.mark.asyncio
-    async def test_create_ticket_with_description(self, ticket_svc: TicketService) -> None:
+    async def test_create_ticket_with_description(
+        self, ticket_svc: TicketService
+    ) -> None:
         """Ticket with initial description stores it."""
         tid = await ticket_svc.create_ticket(
-            GUILD_ID, CHANNEL_ID, 18001, USER_ID,
+            GUILD_ID,
+            CHANNEL_ID,
+            18001,
+            USER_ID,
             initial_description="I need help with X",
         )
         assert tid is not None
@@ -520,7 +573,9 @@ class TestInitialDescription:
         assert ticket["initial_description"] == "I need help with X"
 
     @pytest.mark.asyncio
-    async def test_create_ticket_without_description(self, ticket_svc: TicketService) -> None:
+    async def test_create_ticket_without_description(
+        self, ticket_svc: TicketService
+    ) -> None:
         """Ticket without description stores None."""
         tid = await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 18002, USER_ID)
         assert tid is not None
@@ -669,20 +724,32 @@ class TestMaxOpenTickets:
         assert count == 1
 
     @pytest.mark.asyncio
-    async def test_check_max_open_tickets_under_limit(self, ticket_svc: TicketService) -> None:
+    async def test_check_max_open_tickets_under_limit(
+        self, ticket_svc: TicketService
+    ) -> None:
         """User under the limit can open another ticket."""
         await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 22001, USER_ID)
-        assert await ticket_svc.check_max_open_tickets(GUILD_ID, USER_ID, max_open=3) is True
+        assert (
+            await ticket_svc.check_max_open_tickets(GUILD_ID, USER_ID, max_open=3)
+            is True
+        )
 
     @pytest.mark.asyncio
-    async def test_check_max_open_tickets_at_limit(self, ticket_svc: TicketService) -> None:
+    async def test_check_max_open_tickets_at_limit(
+        self, ticket_svc: TicketService
+    ) -> None:
         """User at the limit cannot open another ticket."""
         await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 23001, USER_ID)
         await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 23002, USER_ID)
-        assert await ticket_svc.check_max_open_tickets(GUILD_ID, USER_ID, max_open=2) is False
+        assert (
+            await ticket_svc.check_max_open_tickets(GUILD_ID, USER_ID, max_open=2)
+            is False
+        )
 
     @pytest.mark.asyncio
-    async def test_check_max_open_tickets_default(self, ticket_svc: TicketService) -> None:
+    async def test_check_max_open_tickets_default(
+        self, ticket_svc: TicketService
+    ) -> None:
         """Default limit is DEFAULT_MAX_OPEN_PER_USER."""
         # Create DEFAULT_MAX_OPEN_PER_USER tickets
         for i in range(DEFAULT_MAX_OPEN_PER_USER):
@@ -777,7 +844,24 @@ class TestRowConverters:
 
     def test_row_to_ticket_full(self) -> None:
         """Full 16-column row is converted correctly."""
-        row = (1, 100, 200, 300, 400, 5, "open", None, 1000, None, 555, 1001, "reason", "desc", 1002, 600)
+        row = (
+            1,
+            100,
+            200,
+            300,
+            400,
+            5,
+            "open",
+            None,
+            1000,
+            None,
+            555,
+            1001,
+            "reason",
+            "desc",
+            1002,
+            600,
+        )
         result = TicketService._row_to_ticket(row)
         assert result["id"] == 1
         assert result["claimed_by"] == 555
@@ -927,25 +1011,15 @@ class TestMultiChannelCategories:
         self, ticket_svc: TicketService
     ) -> None:
         """get_categories_for_channel returns only matching categories."""
-        await ticket_svc.create_category(
-            GUILD_ID, "Alpha", channel_id=PANEL_CHANNEL_A
-        )
-        await ticket_svc.create_category(
-            GUILD_ID, "Beta", channel_id=PANEL_CHANNEL_B
-        )
-        await ticket_svc.create_category(
-            GUILD_ID, "Gamma", channel_id=PANEL_CHANNEL_A
-        )
+        await ticket_svc.create_category(GUILD_ID, "Alpha", channel_id=PANEL_CHANNEL_A)
+        await ticket_svc.create_category(GUILD_ID, "Beta", channel_id=PANEL_CHANNEL_B)
+        await ticket_svc.create_category(GUILD_ID, "Gamma", channel_id=PANEL_CHANNEL_A)
 
-        cats_a = await ticket_svc.get_categories_for_channel(
-            GUILD_ID, PANEL_CHANNEL_A
-        )
+        cats_a = await ticket_svc.get_categories_for_channel(GUILD_ID, PANEL_CHANNEL_A)
         assert len(cats_a) == 2
         assert {c["name"] for c in cats_a} == {"Alpha", "Gamma"}
 
-        cats_b = await ticket_svc.get_categories_for_channel(
-            GUILD_ID, PANEL_CHANNEL_B
-        )
+        cats_b = await ticket_svc.get_categories_for_channel(GUILD_ID, PANEL_CHANNEL_B)
         assert len(cats_b) == 1
         assert cats_b[0]["name"] == "Beta"
 
@@ -958,19 +1032,11 @@ class TestMultiChannelCategories:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_get_ticket_channel_ids(
-        self, ticket_svc: TicketService
-    ) -> None:
+    async def test_get_ticket_channel_ids(self, ticket_svc: TicketService) -> None:
         """get_ticket_channel_ids returns distinct non-zero channel IDs."""
-        await ticket_svc.create_category(
-            GUILD_ID, "A", channel_id=PANEL_CHANNEL_A
-        )
-        await ticket_svc.create_category(
-            GUILD_ID, "B", channel_id=PANEL_CHANNEL_B
-        )
-        await ticket_svc.create_category(
-            GUILD_ID, "C", channel_id=PANEL_CHANNEL_A
-        )
+        await ticket_svc.create_category(GUILD_ID, "A", channel_id=PANEL_CHANNEL_A)
+        await ticket_svc.create_category(GUILD_ID, "B", channel_id=PANEL_CHANNEL_B)
+        await ticket_svc.create_category(GUILD_ID, "C", channel_id=PANEL_CHANNEL_A)
         # Unassigned category (channel_id=0) should NOT appear
         await ticket_svc.create_category(GUILD_ID, "Unassigned")
 
@@ -995,9 +1061,7 @@ class TestMultiChannelCategories:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_update_category_channel_id(
-        self, ticket_svc: TicketService
-    ) -> None:
+    async def test_update_category_channel_id(self, ticket_svc: TicketService) -> None:
         """Updating channel_id on an existing category persists correctly."""
         cat_id = await ticket_svc.create_category(
             GUILD_ID, "Moveable", channel_id=PANEL_CHANNEL_A
@@ -1059,15 +1123,9 @@ class TestMultiChannelCategories:
     ) -> None:
         """Categories returned by channel are ordered by sort_order."""
         # Create in reverse name order — sort_order auto-increments
-        await ticket_svc.create_category(
-            GUILD_ID, "Zebra", channel_id=PANEL_CHANNEL_A
-        )
-        await ticket_svc.create_category(
-            GUILD_ID, "Apple", channel_id=PANEL_CHANNEL_A
-        )
-        cats = await ticket_svc.get_categories_for_channel(
-            GUILD_ID, PANEL_CHANNEL_A
-        )
+        await ticket_svc.create_category(GUILD_ID, "Zebra", channel_id=PANEL_CHANNEL_A)
+        await ticket_svc.create_category(GUILD_ID, "Apple", channel_id=PANEL_CHANNEL_A)
+        cats = await ticket_svc.get_categories_for_channel(GUILD_ID, PANEL_CHANNEL_A)
         assert len(cats) == 2
         # sort_order is auto-incremented, so Zebra (0) before Apple (1)
         assert cats[0]["name"] == "Zebra"
@@ -1262,9 +1320,7 @@ class TestThreadHealth:
         assert health["status"] == "healthy"
 
     @pytest.mark.asyncio
-    async def test_mark_thread_deleted_success(
-        self, ticket_svc: TicketService
-    ) -> None:
+    async def test_mark_thread_deleted_success(self, ticket_svc: TicketService) -> None:
         """mark_thread_deleted sets deleted_at on matching ticket."""
         await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 22001, USER_ID)
         result = await ticket_svc.mark_thread_deleted(22001)
@@ -1293,9 +1349,45 @@ class TestThreadHealth:
         assert await ticket_svc.mark_thread_deleted(23001) is False
 
     @pytest.mark.asyncio
-    async def test_get_oldest_closed_tickets(
+    async def test_get_missing_open_tickets_detects_missing(
         self, ticket_svc: TicketService
     ) -> None:
+        """Missing open threads are returned for reconciliation."""
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 23501, USER_ID)
+
+        missing = await ticket_svc.get_missing_open_tickets(
+            GUILD_ID,
+            lambda thread_id: thread_id != 23501,
+        )
+
+        assert len(missing) == 1
+        assert missing[0]["thread_id"] == 23501
+
+    @pytest.mark.asyncio
+    async def test_reconcile_missing_open_tickets_closes_and_marks_deleted(
+        self, ticket_svc: TicketService
+    ) -> None:
+        """Reconciling a missing open thread closes and soft-deletes it."""
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 23502, USER_ID)
+
+        report = await ticket_svc.reconcile_missing_open_tickets(
+            GUILD_ID,
+            lambda thread_id: False,
+        )
+
+        assert report["checked"] == 1
+        assert report["missing"] == 1
+        assert report["reconciled"] == 1
+        assert report["failed"] == 0
+
+        ticket = await ticket_svc.get_ticket_by_thread(23502)
+        assert ticket is not None
+        assert ticket["status"] == "closed"
+        assert ticket["deleted_at"] is not None
+        assert ticket["closed_by"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_oldest_closed_tickets(self, ticket_svc: TicketService) -> None:
         """Returns closed tickets sorted by oldest closed_at first."""
         tid1 = await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 24001, USER_ID)
         tid2 = await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 24002, USER_ID)

--- a/tests/test_ticket_service.py
+++ b/tests/test_ticket_service.py
@@ -8,6 +8,7 @@ Uses the ``temp_db`` fixture from conftest so each test gets an isolated databas
 from __future__ import annotations
 
 import time
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -1385,6 +1386,44 @@ class TestThreadHealth:
         assert ticket["status"] == "closed"
         assert ticket["deleted_at"] is not None
         assert ticket["closed_by"] == 0
+
+    @pytest.mark.asyncio
+    async def test_reconcile_missing_open_tickets_reuses_open_ticket_query(
+        self,
+        ticket_svc: TicketService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reconciling uses the same open-ticket slice for checks and repairs."""
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 23503, USER_ID)
+        await ticket_svc.create_ticket(GUILD_ID, CHANNEL_ID, 23504, USER_ID)
+        original_get_open_tickets = ticket_svc.get_open_tickets
+        calls = 0
+
+        async def counted_get_open_tickets(
+            guild_id: int,
+            user_id: int | None = None,
+        ) -> list[dict[str, Any]]:
+            nonlocal calls
+            calls += 1
+            return await original_get_open_tickets(guild_id, user_id)
+
+        monkeypatch.setattr(
+            ticket_svc,
+            "get_open_tickets",
+            counted_get_open_tickets,
+        )
+
+        report = await ticket_svc.reconcile_missing_open_tickets(
+            GUILD_ID,
+            lambda thread_id: False,
+            limit=1,
+        )
+
+        assert calls == 1
+        assert report["checked"] == 1
+        assert report["missing"] == 1
+        assert report["reconciled"] == 1
+        assert report["failed"] == 0
 
     @pytest.mark.asyncio
     async def test_get_oldest_closed_tickets(self, ticket_svc: TicketService) -> None:

--- a/tests/test_ticket_views.py
+++ b/tests/test_ticket_views.py
@@ -61,6 +61,14 @@ def _mock_bot_with_services(
     ts.get_category = AsyncMock(return_value=None)
     ts.close_ticket_by_thread = AsyncMock(return_value=True)
     ts.check_max_open_tickets = AsyncMock(return_value=max_open_allowed)
+    ts.reconcile_missing_open_tickets = AsyncMock(
+        return_value={
+            "checked": 0,
+            "missing": 0,
+            "reconciled": 0,
+            "failed": 0,
+        }
+    )
     ts.claim_ticket = AsyncMock(return_value=True)
     ts.unclaim_ticket = AsyncMock(return_value=True)
     ts.reopen_ticket = AsyncMock(return_value=True)
@@ -163,6 +171,7 @@ class TestTicketPanelView:
             public_button_color="ED4245",  # Red -> Danger
         )
         import discord
+
         private_btn = view.children[0]  # type: ignore[attr-defined]
         public_btn = view.children[1]  # type: ignore[attr-defined]
         assert private_btn.style == discord.ButtonStyle.success  # type: ignore[attr-defined]
@@ -224,26 +233,24 @@ class TestTicketPanelView:
             {"id": 10, "name": "Chan-A Only", "description": "", "emoji": None},
             {"id": 20, "name": "Chan-B Only", "description": "", "emoji": None},
         ]
-        bot = _mock_bot_with_services(
-            categories=all_cats, channel_categories=chan_cats
-        )
+        bot = _mock_bot_with_services(categories=all_cats, channel_categories=chan_cats)
         view = TicketPanelView(bot)
         interaction = FakeInteraction()
         interaction.channel_id = 8001  # panel channel
 
         await view._on_create_ticket(interaction)  # type: ignore[arg-type]
         assert interaction.response._is_done
+        assert interaction.guild is not None
         # Should have called get_categories_for_channel with the panel channel
         bot.services.ticket.get_categories_for_channel.assert_called_once_with(
-            interaction.guild.id, 8001  # type: ignore[union-attr]
+            interaction.guild.id,
+            8001,
         )
 
     @pytest.mark.asyncio
     async def test_create_ticket_falls_back_to_all_categories(self) -> None:
         """When channel has no categories, falls back to all guild categories."""
-        all_cats = [
-            {"id": 1, "name": "General", "description": "", "emoji": None}
-        ]
+        all_cats = [{"id": 1, "name": "General", "description": "", "emoji": None}]
         # channel_categories is empty → triggers fallback
         bot = _mock_bot_with_services(categories=all_cats, channel_categories=[])
         view = TicketPanelView(bot)
@@ -268,7 +275,12 @@ class TestTicketCategorySelect:
         """Select options match the provided categories."""
         cats = [
             {"id": 1, "name": "General", "description": "General help", "emoji": "📩"},
-            {"id": 2, "name": "Billing", "description": "Payment issues", "emoji": None},
+            {
+                "id": 2,
+                "name": "Billing",
+                "description": "Payment issues",
+                "emoji": None,
+            },
         ]
         bot = _mock_bot_with_services()
         select = TicketCategorySelect(bot, cats)
@@ -667,6 +679,19 @@ class TestTicketPanelMaxOpen:
 
         await view._on_create_ticket(interaction)  # type: ignore[arg-type]
         assert interaction.response._is_done
+
+    @pytest.mark.asyncio
+    async def test_create_ticket_reconciles_missing_open_rows_first(self) -> None:
+        """Ticket creation should reconcile stale open tickets before checks."""
+        bot = _mock_bot_with_services(max_open_allowed=True)
+        view = TicketPanelView(bot)
+        interaction = FakeInteraction()
+        assert interaction.guild is not None
+        interaction.guild.fetch_channel = AsyncMock(return_value=MagicMock())
+
+        await view._on_create_ticket(interaction)  # type: ignore[arg-type]
+
+        bot.services.ticket.reconcile_missing_open_tickets.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1083,7 +1108,9 @@ class TestTicketDeleteButton:
         interaction.followup.send = followup_send
         thread = MagicMock(spec=discord.Thread)
         thread.id = 55555
-        thread.delete = AsyncMock(side_effect=discord.Forbidden(MagicMock(), "forbidden"))
+        thread.delete = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(), "forbidden")
+        )
         interaction.channel = thread
 
         await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
@@ -1117,7 +1144,10 @@ class TestCloseTicketFlow:
         thread.edit = AsyncMock()
         thread.delete = AsyncMock()
 
-        with patch("helpers.ticket_views._generate_transcript", new=AsyncMock(return_value=None)):
+        with patch(
+            "helpers.ticket_views._generate_transcript",
+            new=AsyncMock(return_value=None),
+        ):
             with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
                 await _close_ticket(bot, interaction, thread, close_reason="Done")  # type: ignore[arg-type]
 
@@ -1142,12 +1172,17 @@ class TestCloseTicketFlow:
         thread.send = AsyncMock()
         thread.edit = AsyncMock(
             side_effect=discord.HTTPException(
-                response=cast("Any", SimpleNamespace(status=500, reason="Server Error")),
+                response=cast(
+                    "Any", SimpleNamespace(status=500, reason="Server Error")
+                ),
                 message="archive failed",
             )
         )
 
-        with patch("helpers.ticket_views._generate_transcript", new=AsyncMock(return_value=None)):
+        with patch(
+            "helpers.ticket_views._generate_transcript",
+            new=AsyncMock(return_value=None),
+        ):
             with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
                 with patch("helpers.ticket_views.logger.exception") as log_exception:
                     await _close_ticket(bot, interaction, thread, close_reason="Done")  # type: ignore[arg-type]

--- a/tests/test_ticket_views.py
+++ b/tests/test_ticket_views.py
@@ -692,6 +692,8 @@ class TestTicketPanelMaxOpen:
         await view._on_create_ticket(interaction)  # type: ignore[arg-type]
 
         bot.services.ticket.reconcile_missing_open_tickets.assert_awaited_once()
+        call_kwargs = bot.services.ticket.reconcile_missing_open_tickets.call_args.kwargs
+        assert call_kwargs["limit"] == 20
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_voice_claim_integration.py
+++ b/tests/test_voice_claim_integration.py
@@ -7,7 +7,6 @@ import pytest_asyncio
 from services.db.database import Database
 from services.voice_service import VoiceService
 from tests.voice_test_helpers import (
-    MockBot,
     MockGuild,
     MockMember,
     MockVoiceChannel,

--- a/tests/test_voice_cleanup.py
+++ b/tests/test_voice_cleanup.py
@@ -4,7 +4,6 @@ Tests for voice channel cleanup functionality.
 Tests the new immediate cleanup when channels become empty and startup reconciliation.
 """
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_voice_transfer_integration.py
+++ b/tests/test_voice_transfer_integration.py
@@ -14,9 +14,7 @@ import pytest
 import pytest_asyncio
 
 from services.db.database import Database
-from services.voice_service import VoiceService
 from tests.voice_test_helpers import (
-    MockBot,
     MockGuild,
     MockMember,
     MockVoiceChannel,

--- a/tests/voice_test_helpers.py
+++ b/tests/voice_test_helpers.py
@@ -148,7 +148,7 @@ async def create_voice_service_with_bot(
     mock_bot = MockBot()
     voice_service = VoiceService(
         config_service,
-        bot=cast(Any, mock_bot),
+        bot=cast("Any", mock_bot),
         test_mode=test_mode,
     )
     await voice_service.initialize()

--- a/web/backend/core/rsi_utils.py
+++ b/web/backend/core/rsi_utils.py
@@ -9,19 +9,15 @@ cascading failures when RSI blocks requests.
 import asyncio
 import logging
 import re
-from typing import TYPE_CHECKING
 
 import aiohttp
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 # Import the shared circuit breaker implementation
 from helpers.circuit_breaker import (
     CircuitBreakerState,
     get_rsi_circuit_breaker,
 )
-
-if TYPE_CHECKING:
-    from bs4 import Tag
 
 logger = logging.getLogger(__name__)
 

--- a/web/backend/tests/test_auth.py
+++ b/web/backend/tests/test_auth.py
@@ -2,9 +2,9 @@
 Tests for authentication endpoints.
 """
 
-import httpx
 from urllib.parse import parse_qs, urlparse
 
+import httpx
 import pytest
 from core.security import (
     create_session_token_async,

--- a/web/backend/tests/test_tickets_routes.py
+++ b/web/backend/tests/test_tickets_routes.py
@@ -14,6 +14,11 @@ from httpx import AsyncClient
 pytestmark = pytest.mark.contract
 
 
+def _set_session(client: AsyncClient, session: str) -> None:
+    """Authenticate the shared test client for multi-request flows."""
+    client.cookies.set("session", session)
+
+
 # ---------------------------------------------------------------------------
 # Categories
 # ---------------------------------------------------------------------------
@@ -24,9 +29,9 @@ async def test_list_categories_empty(
     client: AsyncClient, mock_admin_session: str
 ) -> None:
     """Listing categories for a guild with none returns an empty list."""
+    _set_session(client, mock_admin_session)
     response = await client.get(
         "/api/tickets/categories",
-        cookies={"session": mock_admin_session},
     )
     assert response.status_code == 200
     data = response.json()
@@ -35,10 +40,9 @@ async def test_list_categories_empty(
 
 
 @pytest.mark.asyncio
-async def test_create_category(
-    client: AsyncClient, mock_admin_session: str
-) -> None:
+async def test_create_category(client: AsyncClient, mock_admin_session: str) -> None:
     """Creating a category returns the updated category list."""
+    _set_session(client, mock_admin_session)
     payload = {
         "guild_id": "123",
         "name": "General",
@@ -52,7 +56,6 @@ async def test_create_category(
     response = await client.post(
         "/api/tickets/categories",
         json=payload,
-        cookies={"session": mock_admin_session},
     )
     assert response.status_code == 201
     data = response.json()
@@ -68,6 +71,7 @@ async def test_create_category_guild_mismatch(
     client: AsyncClient, mock_admin_session: str
 ) -> None:
     """Creating a category for a different guild returns 403."""
+    _set_session(client, mock_admin_session)
     payload = {
         "guild_id": "999",  # does not match active guild 123
         "name": "Nope",
@@ -75,21 +79,18 @@ async def test_create_category_guild_mismatch(
     response = await client.post(
         "/api/tickets/categories",
         json=payload,
-        cookies={"session": mock_admin_session},
     )
     assert response.status_code == 403
 
 
 @pytest.mark.asyncio
-async def test_update_category(
-    client: AsyncClient, mock_admin_session: str
-) -> None:
+async def test_update_category(client: AsyncClient, mock_admin_session: str) -> None:
     """Updating a category changes its fields."""
+    _set_session(client, mock_admin_session)
     # Create first
     create_resp = await client.post(
         "/api/tickets/categories",
         json={"guild_id": "123", "name": "Old"},
-        cookies={"session": mock_admin_session},
     )
     cat_id = create_resp.json()["categories"][0]["id"]
 
@@ -97,7 +98,6 @@ async def test_update_category(
     update_resp = await client.put(
         f"/api/tickets/categories/{cat_id}",
         json={"name": "New"},
-        cookies={"session": mock_admin_session},
     )
     assert update_resp.status_code == 200
     assert update_resp.json()["success"] is True
@@ -108,17 +108,16 @@ async def test_update_category_rejects_channel_change(
     client: AsyncClient, mock_admin_session: str
 ) -> None:
     """Category channel assignment cannot be changed via update payload."""
+    _set_session(client, mock_admin_session)
     create_resp = await client.post(
         "/api/tickets/categories",
         json={"guild_id": "123", "name": "Old", "channel_id": "456"},
-        cookies={"session": mock_admin_session},
     )
     cat_id = create_resp.json()["categories"][0]["id"]
 
     update_resp = await client.put(
         f"/api/tickets/categories/{cat_id}",
         json={"channel_id": "789"},
-        cookies={"session": mock_admin_session},
     )
     assert update_resp.status_code == 422
 
@@ -128,6 +127,7 @@ async def test_create_category_invalid_prerequisite_role_ids(
     client: AsyncClient, mock_admin_session: str
 ) -> None:
     """Invalid prerequisite role IDs are rejected by schema validation."""
+    _set_session(client, mock_admin_session)
     payload = {
         "guild_id": "123",
         "name": "General",
@@ -136,7 +136,6 @@ async def test_create_category_invalid_prerequisite_role_ids(
     response = await client.post(
         "/api/tickets/categories",
         json=payload,
-        cookies={"session": mock_admin_session},
     )
     assert response.status_code == 422
 
@@ -146,29 +145,26 @@ async def test_update_category_not_found(
     client: AsyncClient, mock_admin_session: str
 ) -> None:
     """Updating a non-existent category returns 404."""
+    _set_session(client, mock_admin_session)
     response = await client.put(
         "/api/tickets/categories/99999",
         json={"name": "X"},
-        cookies={"session": mock_admin_session},
     )
     assert response.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_delete_category(
-    client: AsyncClient, mock_admin_session: str
-) -> None:
+async def test_delete_category(client: AsyncClient, mock_admin_session: str) -> None:
     """Deleting a category returns success."""
+    _set_session(client, mock_admin_session)
     create_resp = await client.post(
         "/api/tickets/categories",
         json={"guild_id": "123", "name": "ToDelete"},
-        cookies={"session": mock_admin_session},
     )
     cat_id = create_resp.json()["categories"][-1]["id"]
 
     delete_resp = await client.delete(
         f"/api/tickets/categories/{cat_id}",
-        cookies={"session": mock_admin_session},
     )
     assert delete_resp.status_code == 200
     assert delete_resp.json()["success"] is True
@@ -179,9 +175,9 @@ async def test_delete_category_not_found(
     client: AsyncClient, mock_admin_session: str
 ) -> None:
     """Deleting a non-existent category returns 404."""
+    _set_session(client, mock_admin_session)
     response = await client.delete(
         "/api/tickets/categories/99999",
-        cookies={"session": mock_admin_session},
     )
     assert response.status_code == 404
 
@@ -196,6 +192,7 @@ async def test_create_channel_config_with_public_button_fields(
     client: AsyncClient, mock_discord_manager_session: str
 ) -> None:
     """Creating a channel config accepts optional public button fields."""
+    _set_session(client, mock_discord_manager_session)
     response = await client.post(
         "/api/tickets/channels",
         json={
@@ -206,7 +203,6 @@ async def test_create_channel_config_with_public_button_fields(
             "public_button_text": "Create Public Ticket",
             "public_button_emoji": "🌍",
         },
-        cookies={"session": mock_discord_manager_session},
     )
     assert response.status_code == 201
     data = response.json()
@@ -223,10 +219,10 @@ async def test_update_channel_config_public_button_fields(
     client: AsyncClient, mock_discord_manager_session: str
 ) -> None:
     """Updating channel config can toggle public button settings."""
+    _set_session(client, mock_discord_manager_session)
     create_resp = await client.post(
         "/api/tickets/channels",
         json={"guild_id": "123", "channel_id": "789"},
-        cookies={"session": mock_discord_manager_session},
     )
     assert create_resp.status_code == 201
 
@@ -237,14 +233,12 @@ async def test_update_channel_config_public_button_fields(
             "public_button_text": "Open Public Ticket",
             "public_button_emoji": "🌐",
         },
-        cookies={"session": mock_discord_manager_session},
     )
     assert update_resp.status_code == 200
     assert update_resp.json()["success"] is True
 
     list_resp = await client.get(
         "/api/tickets/channels",
-        cookies={"session": mock_discord_manager_session},
     )
     channels = list_resp.json()["channels"]
     target = next((c for c in channels if c["channel_id"] == "789"), None)
@@ -259,6 +253,7 @@ async def test_create_channel_config_with_button_colors_and_order(
     client: AsyncClient, mock_discord_manager_session: str
 ) -> None:
     """Creating a channel config accepts button color and order fields."""
+    _set_session(client, mock_discord_manager_session)
     response = await client.post(
         "/api/tickets/channels",
         json={
@@ -269,7 +264,6 @@ async def test_create_channel_config_with_button_colors_and_order(
             "public_button_color": "ED4245",
             "button_order": "public_first",
         },
-        cookies={"session": mock_discord_manager_session},
     )
     assert response.status_code == 201
     data = response.json()
@@ -285,6 +279,7 @@ async def test_update_channel_config_button_colors(
     client: AsyncClient, mock_discord_manager_session: str
 ) -> None:
     """Updating channel config can modify button colors and order."""
+    _set_session(client, mock_discord_manager_session)
     # Create config
     create_resp = await client.post(
         "/api/tickets/channels",
@@ -293,7 +288,6 @@ async def test_update_channel_config_button_colors(
             "channel_id": "888",
             "enable_public_button": True,
         },
-        cookies={"session": mock_discord_manager_session},
     )
     assert create_resp.status_code == 201
 
@@ -305,7 +299,6 @@ async def test_update_channel_config_button_colors(
             "public_button_color": "4F545C",
             "button_order": "public_first",
         },
-        cookies={"session": mock_discord_manager_session},
     )
     assert update_resp.status_code == 200
     assert update_resp.json()["success"] is True
@@ -313,7 +306,6 @@ async def test_update_channel_config_button_colors(
     # Verify persistence
     list_resp = await client.get(
         "/api/tickets/channels",
-        cookies={"session": mock_discord_manager_session},
     )
     channels = list_resp.json()["channels"]
     target = next((c for c in channels if c["channel_id"] == "888"), None)
@@ -329,13 +321,11 @@ async def test_update_channel_config_button_colors(
 
 
 @pytest.mark.asyncio
-async def test_list_tickets_empty(
-    client: AsyncClient, mock_admin_session: str
-) -> None:
+async def test_list_tickets_empty(client: AsyncClient, mock_admin_session: str) -> None:
     """Listing tickets when none exist returns empty list."""
+    _set_session(client, mock_admin_session)
     response = await client.get(
         "/api/tickets/list",
-        cookies={"session": mock_admin_session},
     )
     assert response.status_code == 200
     data = response.json()
@@ -345,13 +335,11 @@ async def test_list_tickets_empty(
 
 
 @pytest.mark.asyncio
-async def test_ticket_stats_empty(
-    client: AsyncClient, mock_admin_session: str
-) -> None:
+async def test_ticket_stats_empty(client: AsyncClient, mock_admin_session: str) -> None:
     """Stats with no tickets shows zeroes."""
+    _set_session(client, mock_admin_session)
     response = await client.get(
         "/api/tickets/stats",
-        cookies={"session": mock_admin_session},
     )
     assert response.status_code == 200
     data = response.json()
@@ -371,9 +359,9 @@ async def test_get_settings_default(
     client: AsyncClient, mock_discord_manager_session: str
 ) -> None:
     """Getting settings when nothing is configured returns defaults."""
+    _set_session(client, mock_discord_manager_session)
     response = await client.get(
         "/api/tickets/settings",
-        cookies={"session": mock_discord_manager_session},
     )
     assert response.status_code == 200
     data = response.json()
@@ -386,6 +374,7 @@ async def test_update_settings(
     client: AsyncClient, mock_discord_manager_session: str
 ) -> None:
     """Updating settings stores the values."""
+    _set_session(client, mock_discord_manager_session)
     payload = {
         "channel_id": "111222333",
         "close_message": "Thanks!",
@@ -393,7 +382,6 @@ async def test_update_settings(
     response = await client.put(
         "/api/tickets/settings",
         json=payload,
-        cookies={"session": mock_discord_manager_session},
     )
     assert response.status_code == 200
     assert response.json()["success"] is True
@@ -401,7 +389,6 @@ async def test_update_settings(
     # Verify persisted
     get_resp = await client.get(
         "/api/tickets/settings",
-        cookies={"session": mock_discord_manager_session},
     )
     settings = get_resp.json()["settings"]
     assert settings["channel_id"] == "111222333"
@@ -413,10 +400,10 @@ async def test_update_settings_rejects_deprecated_panel_fields(
     client: AsyncClient, mock_discord_manager_session: str
 ) -> None:
     """Deprecated global panel fields should be rejected."""
+    _set_session(client, mock_discord_manager_session)
     response = await client.put(
         "/api/tickets/settings",
         json={"panel_title": "Legacy title"},
-        cookies={"session": mock_discord_manager_session},
     )
     assert response.status_code == 422
 
@@ -431,9 +418,9 @@ async def test_deploy_panel_triggers_internal_api(
     client: AsyncClient, mock_discord_manager_session: str
 ) -> None:
     """deploy-panel should call the internal API and return the result."""
+    _set_session(client, mock_discord_manager_session)
     response = await client.post(
         "/api/tickets/deploy-panel",
-        cookies={"session": mock_discord_manager_session},
     )
     assert response.status_code == 200
     data = response.json()
@@ -448,9 +435,12 @@ async def test_deploy_panel_propagates_internal_api_error(
     fake_internal_api,
 ) -> None:
     """deploy-panel should preserve upstream HTTP status/detail from internal API."""
+    _set_session(client, mock_discord_manager_session)
 
     async def _raise_upstream_error(
-        guild_id: int, *, channel_id: str | None = None,
+        guild_id: int,
+        *,
+        channel_id: str | None = None,
     ) -> dict:
         request = httpx.Request(
             "POST", f"http://127.0.0.1:8082/guilds/{guild_id}/tickets/deploy-panel"
@@ -470,7 +460,6 @@ async def test_deploy_panel_propagates_internal_api_error(
 
     response = await client.post(
         "/api/tickets/deploy-panel",
-        cookies={"session": mock_discord_manager_session},
     )
 
     assert response.status_code == 503
@@ -494,9 +483,9 @@ async def test_settings_require_discord_manager(
     client: AsyncClient, mock_moderator_session: str
 ) -> None:
     """Moderators should not be able to update settings (requires discord_manager)."""
+    _set_session(client, mock_moderator_session)
     response = await client.put(
         "/api/tickets/settings",
         json={"close_message": "Nope"},
-        cookies={"session": mock_moderator_session},
     )
     assert response.status_code == 403


### PR DESCRIPTION
- Updated test cases in `test_ticket_commands.py` to include reconciliation of missing open tickets during cleanup.
- Added new tests in `test_ticket_service.py` to verify exclusion of soft-deleted tickets from queries and counts.
- Enhanced `test_ticket_views.py` to ensure ticket creation reconciles stale open tickets.
- Cleaned up imports and improved code formatting across various test files.
- Modified `rsi_utils.py` to remove unnecessary type checking imports.
- Updated `test_auth.py` and `test_tickets_routes.py` to streamline session handling in tests.

## Summary by Sourcery

Reconcile missing open ticket threads with the Discord state and ensure soft-deleted tickets are excluded from aggregated ticket queries, while updating tests and minor helpers accordingly.

New Features:
- Add service-level helpers to detect and reconcile open tickets whose Discord threads no longer exist, closing and soft-deleting them with a system user marker.
- Invoke reconciliation of missing open tickets from ticket health checks, stats, health commands, and ticket creation to keep the ticket store consistent with Discord.
- Extend the tickets cleanup command with an option to also repair open tickets whose threads are missing, reporting reconciliation results in the summary.
- Introduce a Discord helper to safely check for the existence of a thread, tolerating permission and HTTP errors.

Bug Fixes:
- Exclude soft-deleted ticket rows from general ticket listing, counting, and stats queries so aggregates reflect only active tickets.

Enhancements:
- Refine ticket cleanup and health reporting messages to describe both deletion and repair operations and improve dry-run output.
- Simplify HTTP session handling in backend route tests by centralizing cookie setup and adjust test fixtures for voice services.
- Remove unused type-checking-only imports and perform minor formatting and typing cleanups across services and tests.

Tests:
- Add coverage to ensure generic ticket lists, counts, and stats ignore soft-deleted tickets.
- Add tests for detecting missing open tickets and for reconciling them by closing and soft-deleting the associated rows.
- Extend command- and view-layer tests to verify reconciliation is invoked during cleanup operations and ticket creation flows, and to exercise new cleanup options.