### PR TITLE
Add confirmation modal for ticket deletion

### DIFF
--- a/helpers/ticket_views.py
+++ b/helpers/ticket_views.py
@@ -152,9 +152,7 @@ async def _post_deleted_ticket_transcript(
             return
 
         creator_id = ticket.get("user_id")
-        creator_line = (
-            f"<@{creator_id}>" if isinstance(creator_id, int) else "unknown"
-        )
+        creator_line = f"<@{creator_id}>" if isinstance(creator_id, int) else "unknown"
         embed = create_embed(
             title="🗑️ Ticket Deleted",
             description=(
@@ -365,6 +363,34 @@ class TicketCloseReasonModal(Modal, title="Close Ticket"):
         await _close_ticket(self.bot, interaction, self._thread, close_reason=reason)
 
 
+class TicketDeleteConfirmModal(Modal, title="Delete Ticket"):
+    """Modal requiring explicit confirmation before deleting a ticket thread."""
+
+    confirm_input: TextInput = TextInput(
+        label="Type DELETE to confirm",
+        style=discord.TextStyle.short,
+        placeholder="DELETE",
+        required=True,
+        max_length=16,
+    )
+
+    def __init__(self, bot: MyBot, thread: discord.Thread) -> None:
+        super().__init__()
+        self.bot = bot
+        self._thread = thread
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        """Validate typed confirmation and proceed with delete flow."""
+        if (self.confirm_input.value or "").strip().upper() != "DELETE":
+            await interaction.response.send_message(
+                "Deletion cancelled. Type DELETE to confirm.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        await _delete_ticket(self.bot, interaction, self._thread)
+
+
 # ---------------------------------------------------------------------------
 # Panel View — sits on the welcome message in the ticket channel
 # ---------------------------------------------------------------------------
@@ -393,8 +419,12 @@ class TicketPanelView(View):
         self.bot = bot
 
         # Convert color hex codes to Discord button styles
-        private_style = self._color_to_button_style(private_button_color, discord.ButtonStyle.primary)
-        public_style = self._color_to_button_style(public_button_color, discord.ButtonStyle.secondary)
+        private_style = self._color_to_button_style(
+            private_button_color, discord.ButtonStyle.primary
+        )
+        public_style = self._color_to_button_style(
+            public_button_color, discord.ButtonStyle.secondary
+        )
 
         create_btn: Button = Button(
             label=private_button_text,
@@ -424,7 +454,9 @@ class TicketPanelView(View):
                 self.add_item(public_btn)
 
     @staticmethod
-    def _color_to_button_style(color: str | None, default: discord.ButtonStyle) -> discord.ButtonStyle:
+    def _color_to_button_style(
+        color: str | None, default: discord.ButtonStyle
+    ) -> discord.ButtonStyle:
         """Convert a hex color code to a Discord button style.
 
         Supports common color mappings:
@@ -442,7 +474,13 @@ class TicketPanelView(View):
         normalized = color.strip().upper().lstrip("#")
 
         # Map common colors to button styles
-        if normalized in ("5865F2", "5865F3", "5865F4", "0099FF", "3B88F3"):  # Blue/Blurple
+        if normalized in (
+            "5865F2",
+            "5865F3",
+            "5865F4",
+            "0099FF",
+            "3B88F3",
+        ):  # Blue/Blurple
             return discord.ButtonStyle.primary
         elif normalized in ("4E5058", "4F545C", "6C757D", "2C2F33"):  # Gray
             return discord.ButtonStyle.secondary
@@ -498,7 +536,9 @@ class TicketPanelView(View):
 
         # --- Max open tickets check ---
         max_open_raw = await config_service.get_guild_setting(
-            guild_id, "tickets.max_open_per_user", default=str(DEFAULT_MAX_OPEN_PER_USER)
+            guild_id,
+            "tickets.max_open_per_user",
+            default=str(DEFAULT_MAX_OPEN_PER_USER),
         )
         try:
             max_open = int(max_open_raw)
@@ -813,7 +853,7 @@ class TicketActionView(View):
     # -- Close --
 
     async def _on_close_ticket(self, interaction: discord.Interaction) -> None:
-        """Handle the 'Close Ticket' button — show close-reason modal."""
+        """Handle the 'Close Ticket' button by showing the close-reason modal."""
         if interaction.guild is None or not isinstance(
             interaction.channel, discord.Thread
         ):
@@ -840,7 +880,9 @@ class TicketActionView(View):
         is_staff = False
 
         if isinstance(interaction.user, discord.Member):
-            category_role_ids = await _get_ticket_category_role_ids(ticket_service, ticket)
+            category_role_ids = await _get_ticket_category_role_ids(
+                ticket_service, ticket
+            )
             is_staff = await _get_staff_and_check(
                 self.bot,
                 guild_id,
@@ -854,7 +896,6 @@ class TicketActionView(View):
             )
             return
 
-        # Show the close-reason modal
         modal = TicketCloseReasonModal(self.bot, thread)
         await interaction.response.send_modal(modal)
 
@@ -885,7 +926,9 @@ class TicketActionView(View):
         is_creator = user_id == ticket["user_id"]
         is_staff = False
         if isinstance(interaction.user, discord.Member):
-            category_role_ids = await _get_ticket_category_role_ids(ticket_service, ticket)
+            category_role_ids = await _get_ticket_category_role_ids(
+                ticket_service, ticket
+            )
             is_staff = await _get_staff_and_check(
                 self.bot,
                 guild_id,
@@ -901,7 +944,9 @@ class TicketActionView(View):
 
         # Check reopen window
         reopen_window_raw = await config_service.get_guild_setting(
-            guild_id, "tickets.reopen_window_hours", default=str(DEFAULT_REOPEN_WINDOW_HOURS)
+            guild_id,
+            "tickets.reopen_window_hours",
+            default=str(DEFAULT_REOPEN_WINDOW_HOURS),
         )
         try:
             reopen_window = int(reopen_window_raw)
@@ -959,7 +1004,7 @@ class TicketActionView(View):
         await interaction.followup.send("Ticket reopened.", ephemeral=True)
 
     async def _on_delete_ticket(self, interaction: discord.Interaction) -> None:
-        """Handle the 'Delete Ticket' button — delete the Discord thread."""
+        """Handle 'Delete Ticket' by showing typed confirmation modal first."""
         if interaction.guild is None or not isinstance(
             interaction.channel, discord.Thread
         ):
@@ -984,7 +1029,9 @@ class TicketActionView(View):
         is_creator = user_id == ticket["user_id"]
         is_staff = False
         if isinstance(interaction.user, discord.Member):
-            category_role_ids = await _get_ticket_category_role_ids(ticket_service, ticket)
+            category_role_ids = await _get_ticket_category_role_ids(
+                ticket_service, ticket
+            )
             is_staff = await _get_staff_and_check(
                 self.bot,
                 guild_id,
@@ -998,74 +1045,8 @@ class TicketActionView(View):
             )
             return
 
-        await interaction.response.defer(ephemeral=True)
-
-        transcript_file: discord.File | None = None
-        try:
-            transcript_file = await _generate_transcript(thread)
-        except Exception as e:
-            logger.exception(
-                "Failed to generate transcript for deleted thread %s in guild %s",
-                thread.id,
-                guild_id,
-                exc_info=e,
-            )
-
-        try:
-            await thread.delete(
-                reason=(
-                    f"Ticket deleted by {interaction.user} "
-                    f"({interaction.user.id})"
-                )
-            )
-        except discord.Forbidden as e:
-            logger.exception(
-                "Failed to delete thread %s in guild %s due to permissions",
-                thread.id,
-                guild_id,
-                exc_info=e,
-            )
-            await interaction.followup.send(
-                "I don't have permission to delete this thread.", ephemeral=True
-            )
-            return
-        except discord.HTTPException as e:
-            logger.exception(
-                "Discord API error while deleting thread %s in guild %s",
-                thread.id,
-                guild_id,
-                exc_info=e,
-            )
-            await interaction.followup.send(
-                "Failed to delete this thread due to a Discord API error.",
-                ephemeral=True,
-            )
-            return
-
-        # Mark the ticket's thread as deleted in the DB for analytics
-        await ticket_service.mark_thread_deleted(thread.id)
-
-        await _post_deleted_ticket_transcript(
-            self.bot,
-            guild_id,
-            thread=thread,
-            deleted_by=interaction.user,
-            ticket=ticket,
-            transcript_file=transcript_file,
-        )
-
-        await _log_ticket_event(
-            self.bot,
-            guild_id,
-            title="🗑️ Ticket Deleted",
-            description=(
-                f"**Thread:** `{thread.id}`\n"
-                f"**Deleted by:** {interaction.user.mention}"
-            ),
-            color=EmbedColors.WARNING,
-        )
-
-        await interaction.followup.send("Ticket thread deleted.", ephemeral=True)
+        modal = TicketDeleteConfirmModal(self.bot, thread)
+        await interaction.response.send_modal(modal)
 
 
 # ---------------------------------------------------------------------------
@@ -1097,7 +1078,9 @@ async def _start_dynamic_form(
 
     # Create fresh session
     ctx = await ticket_form_service.create_session(
-        guild_id, user_id, category["id"],
+        guild_id,
+        user_id,
+        category["id"],
         interaction_token=interaction.token,
         is_public=is_public,
     )
@@ -1220,9 +1203,7 @@ async def _create_ticket_thread(
     try:
         await thread.add_user(user)
     except discord.Forbidden:
-        logger.debug(
-            "No permission to add user %s to thread %s", user.id, thread.id
-        )
+        logger.debug("No permission to add user %s to thread %s", user.id, thread.id)
     except discord.HTTPException as exc:
         logger.warning(
             "Could not add user %s to thread %s: %s",
@@ -1341,6 +1322,95 @@ async def _create_ticket_thread(
     )
 
     return ticket_id
+
+
+# ---------------------------------------------------------------------------
+# Delete ticket flow
+# ---------------------------------------------------------------------------
+
+
+async def _delete_ticket(
+    bot: MyBot,
+    interaction: discord.Interaction,
+    thread: discord.Thread,
+) -> None:
+    """Delete a ticket thread after confirmation and preserve audit behavior."""
+    if interaction.guild is None:
+        await interaction.followup.send("Missing guild context.", ephemeral=True)
+        return
+
+    guild_id = interaction.guild.id
+    ticket_service = bot.services.ticket
+
+    ticket = await ticket_service.get_ticket_by_thread(thread.id)
+    if ticket is None:
+        await interaction.followup.send(
+            "Could not find a ticket record for this thread.", ephemeral=True
+        )
+        return
+
+    transcript_file: discord.File | None = None
+    try:
+        transcript_file = await _generate_transcript(thread)
+    except Exception as e:
+        logger.exception(
+            "Failed to generate transcript for deleted thread %s in guild %s",
+            thread.id,
+            guild_id,
+            exc_info=e,
+        )
+
+    try:
+        await thread.delete(
+            reason=(f"Ticket deleted by {interaction.user} ({interaction.user.id})")
+        )
+    except discord.Forbidden as e:
+        logger.exception(
+            "Failed to delete thread %s in guild %s due to permissions",
+            thread.id,
+            guild_id,
+            exc_info=e,
+        )
+        await interaction.followup.send(
+            "I don't have permission to delete this thread.", ephemeral=True
+        )
+        return
+    except discord.HTTPException as e:
+        logger.exception(
+            "Discord API error while deleting thread %s in guild %s",
+            thread.id,
+            guild_id,
+            exc_info=e,
+        )
+        await interaction.followup.send(
+            "Failed to delete this thread due to a Discord API error.",
+            ephemeral=True,
+        )
+        return
+
+    # Mark the ticket's thread as deleted in the DB for analytics
+    await ticket_service.mark_thread_deleted(thread.id)
+
+    await _post_deleted_ticket_transcript(
+        bot,
+        guild_id,
+        thread=thread,
+        deleted_by=interaction.user,
+        ticket=ticket,
+        transcript_file=transcript_file,
+    )
+
+    await _log_ticket_event(
+        bot,
+        guild_id,
+        title="🗑️ Ticket Deleted",
+        description=(
+            f"**Thread:** `{thread.id}`\n**Deleted by:** {interaction.user.mention}"
+        ),
+        color=EmbedColors.WARNING,
+    )
+
+    await interaction.followup.send("Ticket thread deleted.", ephemeral=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ticket_views.py
+++ b/tests/test_ticket_views.py
@@ -18,6 +18,7 @@ from helpers.ticket_views import (
     TicketActionView,
     TicketCategorySelect,
     TicketCloseReasonModal,
+    TicketDeleteConfirmModal,
     TicketDescriptionModal,
     TicketPanelView,
     _close_ticket,
@@ -163,6 +164,7 @@ class TestTicketPanelView:
             public_button_color="ED4245",  # Red -> Danger
         )
         import discord
+
         private_btn = view.children[0]  # type: ignore[attr-defined]
         public_btn = view.children[1]  # type: ignore[attr-defined]
         assert private_btn.style == discord.ButtonStyle.success  # type: ignore[attr-defined]
@@ -224,9 +226,7 @@ class TestTicketPanelView:
             {"id": 10, "name": "Chan-A Only", "description": "", "emoji": None},
             {"id": 20, "name": "Chan-B Only", "description": "", "emoji": None},
         ]
-        bot = _mock_bot_with_services(
-            categories=all_cats, channel_categories=chan_cats
-        )
+        bot = _mock_bot_with_services(categories=all_cats, channel_categories=chan_cats)
         view = TicketPanelView(bot)
         interaction = FakeInteraction()
         interaction.channel_id = 8001  # panel channel
@@ -235,15 +235,14 @@ class TestTicketPanelView:
         assert interaction.response._is_done
         # Should have called get_categories_for_channel with the panel channel
         bot.services.ticket.get_categories_for_channel.assert_called_once_with(
-            interaction.guild.id, 8001  # type: ignore[union-attr]
+            interaction.guild.id,
+            8001,  # type: ignore[union-attr]
         )
 
     @pytest.mark.asyncio
     async def test_create_ticket_falls_back_to_all_categories(self) -> None:
         """When channel has no categories, falls back to all guild categories."""
-        all_cats = [
-            {"id": 1, "name": "General", "description": "", "emoji": None}
-        ]
+        all_cats = [{"id": 1, "name": "General", "description": "", "emoji": None}]
         # channel_categories is empty → triggers fallback
         bot = _mock_bot_with_services(categories=all_cats, channel_categories=[])
         view = TicketPanelView(bot)
@@ -268,7 +267,12 @@ class TestTicketCategorySelect:
         """Select options match the provided categories."""
         cats = [
             {"id": 1, "name": "General", "description": "General help", "emoji": "📩"},
-            {"id": 2, "name": "Billing", "description": "Payment issues", "emoji": None},
+            {
+                "id": 2,
+                "name": "Billing",
+                "description": "Payment issues",
+                "emoji": None,
+            },
         ]
         bot = _mock_bot_with_services()
         select = TicketCategorySelect(bot, cats)
@@ -492,7 +496,6 @@ class TestTicketActionView:
         interaction.channel = thread
 
         await view._on_close_ticket(interaction)  # type: ignore[arg-type]
-        # Should send a close-reason modal
         assert interaction.response._is_done
         assert interaction.response.sent_modal is not None
         assert isinstance(interaction.response.sent_modal, TicketCloseReasonModal)
@@ -898,7 +901,7 @@ class TestTicketDeleteButton:
 
     @pytest.mark.asyncio
     async def test_delete_ticket_creator_allowed(self) -> None:
-        """Ticket creator can delete the thread."""
+        """Ticket creator can delete the thread after typed confirmation."""
         ticket = {"id": 1, "user_id": 42, "guild_id": 123}
         bot = _mock_bot_with_services(ticket=ticket, staff_roles="[]")
         view = TicketActionView(bot)
@@ -918,6 +921,16 @@ class TestTicketDeleteButton:
         thread.delete = AsyncMock()
         interaction.channel = thread
 
+        await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+        assert interaction.response._is_done
+        assert interaction.response.sent_modal is not None
+        assert isinstance(interaction.response.sent_modal, TicketDeleteConfirmModal)
+
+        modal = interaction.response.sent_modal
+        modal.confirm_input._value = "DELETE"  # type: ignore[attr-defined]
+        submit_interaction = FakeInteraction(user=user)
+        submit_interaction.followup.send = followup_send
+
         with patch(
             "helpers.ticket_views._generate_transcript",
             new=AsyncMock(return_value=None),
@@ -927,11 +940,44 @@ class TestTicketDeleteButton:
                 new=AsyncMock(),
             ):
                 with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
-                    await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+                    await modal.on_submit(
+                        cast("discord.Interaction", submit_interaction)
+                    )
 
         thread.delete.assert_awaited_once()
         bot.services.ticket.mark_thread_deleted.assert_awaited_once_with(55555)
         followup_send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_ticket_rejects_invalid_confirmation(self) -> None:
+        """Delete modal rejects input other than DELETE and keeps thread."""
+        ticket = {"id": 1, "user_id": 42, "guild_id": 123}
+        bot = _mock_bot_with_services(ticket=ticket, staff_roles="[]")
+        view = TicketActionView(bot)
+
+        user = MagicMock(spec=discord.Member)
+        user.id = 42
+        user.roles = []
+        user.mention = "@creator"
+        user.guild_permissions = MagicMock()
+        user.guild_permissions.administrator = False
+
+        interaction = FakeInteraction(user=user)
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 55555
+        thread.delete = AsyncMock()
+        interaction.channel = thread
+
+        await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+        modal = interaction.response.sent_modal
+        assert isinstance(modal, TicketDeleteConfirmModal)
+
+        modal.confirm_input._value = "NOPE"  # type: ignore[attr-defined]
+        submit_interaction = FakeInteraction(user=user)
+        await modal.on_submit(cast("discord.Interaction", submit_interaction))
+
+        thread.delete.assert_not_awaited()
+        bot.services.ticket.mark_thread_deleted.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_delete_ticket_posts_transcript_to_leadership(self) -> None:
@@ -956,6 +1002,13 @@ class TestTicketDeleteButton:
 
         transcript = MagicMock(spec=discord.File)
 
+        await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+        modal = interaction.response.sent_modal
+        assert isinstance(modal, TicketDeleteConfirmModal)
+        modal.confirm_input._value = "DELETE"  # type: ignore[attr-defined]
+        submit_interaction = FakeInteraction(user=user)
+        submit_interaction.followup.send = interaction.followup.send
+
         with patch(
             "helpers.ticket_views._generate_transcript",
             new=AsyncMock(return_value=transcript),
@@ -965,7 +1018,9 @@ class TestTicketDeleteButton:
                 new=AsyncMock(),
             ) as leadership_post:
                 with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
-                    await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+                    await modal.on_submit(
+                        cast("discord.Interaction", submit_interaction)
+                    )
 
         leadership_post.assert_awaited_once()
         assert leadership_post.await_args is not None
@@ -996,6 +1051,13 @@ class TestTicketDeleteButton:
         thread.delete = AsyncMock()
         interaction.channel = thread
 
+        await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+        modal = interaction.response.sent_modal
+        assert isinstance(modal, TicketDeleteConfirmModal)
+        modal.confirm_input._value = "DELETE"  # type: ignore[attr-defined]
+        submit_interaction = FakeInteraction(user=user)
+        submit_interaction.followup.send = interaction.followup.send
+
         with patch(
             "helpers.ticket_views._generate_transcript",
             new=AsyncMock(side_effect=RuntimeError("boom")),
@@ -1005,7 +1067,9 @@ class TestTicketDeleteButton:
                 new=AsyncMock(),
             ) as leadership_post:
                 with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
-                    await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+                    await modal.on_submit(
+                        cast("discord.Interaction", submit_interaction)
+                    )
 
         thread.delete.assert_awaited_once()
         bot.services.ticket.mark_thread_deleted.assert_awaited_once_with(55555)
@@ -1083,10 +1147,20 @@ class TestTicketDeleteButton:
         interaction.followup.send = followup_send
         thread = MagicMock(spec=discord.Thread)
         thread.id = 55555
-        thread.delete = AsyncMock(side_effect=discord.Forbidden(MagicMock(), "forbidden"))
+        thread.delete = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(), "forbidden")
+        )
         interaction.channel = thread
 
         await view._on_delete_ticket(interaction)  # type: ignore[arg-type]
+        modal = interaction.response.sent_modal
+        assert isinstance(modal, TicketDeleteConfirmModal)
+        modal.confirm_input._value = "DELETE"  # type: ignore[attr-defined]
+
+        submit_interaction = FakeInteraction(user=user)
+        submit_interaction.followup.send = followup_send
+
+        await modal.on_submit(cast("discord.Interaction", submit_interaction))
 
         followup_send.assert_awaited()
         assert followup_send.await_args is not None
@@ -1117,7 +1191,10 @@ class TestCloseTicketFlow:
         thread.edit = AsyncMock()
         thread.delete = AsyncMock()
 
-        with patch("helpers.ticket_views._generate_transcript", new=AsyncMock(return_value=None)):
+        with patch(
+            "helpers.ticket_views._generate_transcript",
+            new=AsyncMock(return_value=None),
+        ):
             with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
                 await _close_ticket(bot, interaction, thread, close_reason="Done")  # type: ignore[arg-type]
 
@@ -1142,12 +1219,17 @@ class TestCloseTicketFlow:
         thread.send = AsyncMock()
         thread.edit = AsyncMock(
             side_effect=discord.HTTPException(
-                response=cast("Any", SimpleNamespace(status=500, reason="Server Error")),
+                response=cast(
+                    "Any", SimpleNamespace(status=500, reason="Server Error")
+                ),
                 message="archive failed",
             )
         )
 
-        with patch("helpers.ticket_views._generate_transcript", new=AsyncMock(return_value=None)):
+        with patch(
+            "helpers.ticket_views._generate_transcript",
+            new=AsyncMock(return_value=None),
+        ):
             with patch("helpers.ticket_views._log_ticket_event", new=AsyncMock()):
                 with patch("helpers.ticket_views.logger.exception") as log_exception:
                     await _close_ticket(bot, interaction, thread, close_reason="Done")  # type: ignore[arg-type]


### PR DESCRIPTION
Introduce a confirmation modal that prompts users to confirm ticket deletion, enhancing the deletion flow by requiring explicit confirmation from the ticket creator.

## Summary by Sourcery

Require explicit typed confirmation before deleting tickets and centralize the ticket deletion flow for consistent auditing and error handling.

New Features:
- Introduce a ticket deletion confirmation modal that requires users to type DELETE before a ticket thread is removed.

Enhancements:
- Extract ticket deletion logic into a dedicated helper to preserve transcript generation, logging, and analytics behavior.
- Tidy up helper formatting and docstrings for ticket view utilities.

Tests:
- Extend ticket deletion tests to cover the confirmation modal flow, including valid and invalid confirmation, transcript handling, and error conditions.