### PR TITLE
Update event editor for open-ended events and default duration mode

### DIFF
--- a/web/frontend/src/pages/EventEditor.test.tsx
+++ b/web/frontend/src/pages/EventEditor.test.tsx
@@ -251,6 +251,7 @@ describe('EventEditor Page', () => {
         expect.objectContaining({
           name: 'Created Event',
           entity_type: 'voice',
+          scheduled_end_time: null,
           channel_id: '11',
           location: null,
           announcement_channel_id: '10',
@@ -331,6 +332,8 @@ describe('EventEditor Page', () => {
       target: { value: '20:00' },
     });
 
+    expect(screen.queryByRole('button', { name: 'Open-ended' })).not.toBeInTheDocument();
+
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
     fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
@@ -341,8 +344,56 @@ describe('EventEditor Page', () => {
         expect.objectContaining({
           name: 'External Briefing',
           entity_type: 'external',
+          scheduled_end_time: expect.any(String),
           channel_id: null,
           location: 'Area 18 expo hall',
+        }),
+      );
+    });
+  });
+
+  it('recovers malformed external events without end time by defaulting to duration mode', async () => {
+    vi.mocked(eventsApi.getScheduledEvent).mockResolvedValue({
+      success: true,
+      event: {
+        id: '556',
+        name: 'External Event Missing End',
+        description: 'Imported external event',
+        scheduled_start_time: '2099-04-09T20:00:00+00:00',
+        scheduled_end_time: null,
+        status: 'scheduled',
+        entity_type: 'external',
+        channel_id: null,
+        channel_name: null,
+        location: 'Area 18 expo hall',
+        user_count: 2,
+        creator_id: '444333222',
+        creator_name: 'Coordinator',
+        image_url: null,
+      },
+    });
+
+    renderWithRouter('/events/556/edit');
+
+    await waitFor(() => {
+      expect(eventsApi.getScheduledEvent).toHaveBeenCalledWith('123', '556');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(screen.queryByRole('button', { name: 'Open-ended' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    await waitFor(() => {
+      expect(eventsApi.updateScheduledEvent).toHaveBeenCalledWith(
+        '123',
+        '556',
+        expect.objectContaining({
+          entity_type: 'external',
+          scheduled_end_time: expect.any(String),
         }),
       );
     });

--- a/web/frontend/src/pages/EventEditor.tsx
+++ b/web/frontend/src/pages/EventEditor.tsx
@@ -126,10 +126,18 @@ function EventEditor({ guildId, mode }: EventEditorProps) {
 
   const updateDraft = useCallback((patch: Partial<EventDraft>) => {
     setBuilderError(null);
-    setDraft((currentDraft) => ({
-      ...currentDraft,
-      ...patch,
-    }));
+    setDraft((currentDraft) => {
+      const nextDraft = {
+        ...currentDraft,
+        ...patch,
+      };
+
+      if (nextDraft.locationMode === 'external' && nextDraft.endMode === 'open') {
+        nextDraft.endMode = 'duration';
+      }
+
+      return nextDraft;
+    });
   }, []);
 
   const loadEditorData = useCallback(async () => {
@@ -194,6 +202,9 @@ function EventEditor({ guildId, mode }: EventEditorProps) {
         }
       } else {
         nextDraft.channelId = null;
+        if (nextDraft.endMode === 'open') {
+          nextDraft.endMode = 'duration';
+        }
       }
 
       if (

--- a/web/frontend/src/pages/EventEditorSteps.tsx
+++ b/web/frontend/src/pages/EventEditorSteps.tsx
@@ -141,6 +141,17 @@ interface DetailsStepProps {
 
 export function DetailsStep({ draft, updateDraft, computedEndTime }: DetailsStepProps) {
   const [imageError, setImageError] = useState<string | null>(null);
+  const endModeOptions =
+    draft.locationMode === 'external'
+      ? [
+          { id: 'duration', label: 'Use duration' },
+          { id: 'manual', label: 'Set end time' },
+        ]
+      : [
+          { id: 'duration', label: 'Use duration' },
+          { id: 'manual', label: 'Set end time' },
+          { id: 'open', label: 'Open-ended' },
+        ];
 
   const handleImageChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -182,11 +193,7 @@ export function DetailsStep({ draft, updateDraft, computedEndTime }: DetailsStep
 
       <div className="space-y-3">
         <div className="flex flex-wrap gap-2">
-          {[
-            { id: 'duration', label: 'Use duration' },
-            { id: 'manual', label: 'Set end time' },
-            { id: 'open', label: 'Open-ended' },
-          ].map((option) => (
+          {endModeOptions.map((option) => (
             <button key={option.id} type="button" onClick={() => updateDraft({ endMode: option.id as EndMode })} className={getOptionButtonClass(draft.endMode === option.id)}>
               {option.label}
             </button>

--- a/web/frontend/src/pages/eventFlowShared.ts
+++ b/web/frontend/src/pages/eventFlowShared.ts
@@ -158,7 +158,7 @@ export function createEmptyDraft(settings: EventModuleSettingsPayload | null): E
     location: '',
     startDate: '',
     startTime: '',
-    endMode: 'duration',
+    endMode: 'open',
     durationMinutes: '120',
     endDate: '',
     endTime: '',
@@ -189,6 +189,23 @@ export function createDraftFromEvent(
       : '120';
   const recurrencePayload = event.recurrence_rule_payload;
   const locationMode = getLocationModeFromEntityType(event.entity_type);
+  const hasScheduledEndTime = Boolean(event.scheduled_end_time);
+  let endMode: EndMode = hasScheduledEndTime ? 'manual' : 'open';
+  let endDate = end.date;
+  let endTimeValue = end.time;
+
+  // External events require an end time. If a malformed event has none,
+  // fall back to duration mode so the editor can recover safely.
+  if (!hasScheduledEndTime && locationMode === 'external') {
+    endMode = 'duration';
+    if (start.date && start.time) {
+      const startDateTime = new Date(combineDateAndTime(start.date, start.time));
+      const fallbackEndDateTime = new Date(startDateTime.getTime() + 120 * 60000);
+      const fallbackEnd = splitDateAndTime(fallbackEndDateTime.toISOString());
+      endDate = fallbackEnd.date;
+      endTimeValue = fallbackEnd.time;
+    }
+  }
 
   return {
     name: event.name,
@@ -199,10 +216,10 @@ export function createDraftFromEvent(
     location: event.location ?? '',
     startDate: start.date,
     startTime: start.time,
-    endMode: event.scheduled_end_time ? 'manual' : 'open',
+    endMode,
     durationMinutes,
-    endDate: end.date,
-    endTime: end.time,
+    endDate,
+    endTime: endTimeValue,
     announcementChannelId: settings?.default_announcement_channel_id ?? null,
     signupRoleIds: [],
     recurrenceEnabled: !!recurrencePayload,


### PR DESCRIPTION
Enhance the event editor to handle open-ended events properly and default to duration mode for malformed external events. This change improves user experience by ensuring that events without an end time are managed effectively.

## Summary by Sourcery

Improve event editor handling of open-ended and malformed external events, adjusting default end mode behavior and UI options accordingly.

Bug Fixes:
- Ensure external events without an end time are recovered by defaulting to duration mode with a sensible fallback end time.
- Prevent external events from being configured as open-ended, enforcing a required end time in the editor.

Enhancements:
- Change default draft end mode to open-ended for new non-external events while preserving proper behavior for external events.

Tests:
- Add and update event editor tests to cover open-ended scheduling for created events and recovery of malformed external external events without an end time.